### PR TITLE
Add "submitting" status, to workaround slow compile queries

### DIFF
--- a/neuroscout/models/analysis.py
+++ b/neuroscout/models/analysis.py
@@ -37,7 +37,7 @@ class Analysis(db.Model):
 
     status = db.Column(db.Text, default='DRAFT')
     __table_args__ = (
-    	db.CheckConstraint(status.in_(['PASSED', 'FAILED', 'PENDING', 'DRAFT'])), )
+    	db.CheckConstraint(status.in_(['PASSED', 'FAILED', 'SUBMITTING', 'PENDING', 'DRAFT'])), )
 
     compile_traceback = db.Column(db.Text, default='')
     celery_id = db.Column(db.Text) # Celery task id

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -23,6 +23,7 @@ class PredictorEvent(db.Model):
 	""" An event within a Predictor. Onset is relative to run. """
 	__table_args__ = (
 	    db.UniqueConstraint('onset', 'run_id', 'predictor_id', 'object_id'),
+		db.Index('ix_predictor_id_run_id', "predictor_id", "run_id")
 	)
 	id = db.Column(db.Integer, primary_key=True)
 
@@ -31,9 +32,10 @@ class PredictorEvent(db.Model):
 	value = db.Column(db.String, nullable=False)
 	object_id = db.Column(db.Integer)
 
-	run_id = db.Column(db.Integer, db.ForeignKey('run.id'), nullable=False)
+	run_id = db.Column(db.Integer, db.ForeignKey('run.id'), nullable=False,
+					index=True)
 	predictor_id = db.Column(db.Integer, db.ForeignKey('predictor.id'),
-							nullable=False)
+							nullable=False, index=True)
 	stimulus_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))
 
 	def __repr__(self):

--- a/neuroscout/resources/analysis/endpoints.py
+++ b/neuroscout/resources/analysis/endpoints.py
@@ -94,15 +94,18 @@ class CompileAnalysisResource(AnalysisBaseResource):
 	@doc(summary='Compile and lock analysis.')
 	@owner_required
 	def post(self, analysis):
-		analysis.status = 'PENDING'
+		analysis.status = 'SUBMITTING'
 		analysis.compile_traceback = ''
+		db.session.add(analysis)
+		db.session.commit()
 		task = celery_app.send_task('workflow.compile',
 				args=[*json_analysis(analysis),
 				analysis.dataset.local_path])
 		analysis.celery_id = task.id
-
+		analysis.status = 'PENDING'
 		db.session.add(analysis)
 		db.session.commit()
+
 		return analysis
 
 class AnalysisStatusResource(AnalysisBaseResource):

--- a/neuroscout/resources/analysis/endpoints.py
+++ b/neuroscout/resources/analysis/endpoints.py
@@ -77,13 +77,18 @@ class CloneAnalysisResource(AnalysisBaseResource):
 
 
 def json_analysis(analysis):
+	"""" Dump an analysis object to JSON for compilation.
+	This requires querying the PredictorEvents to get all events for all runs
+	and predictors. This function is somewhat slow due to the overhead of
+	creating Python objects (and dumping through Marshmallow), tens of thousands
+	of runs."""
 	analysis_json = AnalysisFullSchema().dump(analysis)[0]
 
 	pred_ids = [p.id for p in analysis.predictors]
 	run_ids = [r.id for r in analysis.runs]
 	pes = PredictorEvent.query.filter(
 	    (PredictorEvent.predictor_id.in_(pred_ids)) & \
-	    (PredictorEvent.run_id.in_(run_ids))).all()
+	    (PredictorEvent.run_id.in_(run_ids)))
 	pes_json = PredictorEventSchema(many=True, exclude=['id']).dump(pes)[0]
 
 	resources_json = AnalysisResourcesSchema().dump(analysis)[0]

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -49,8 +49,10 @@ class PredictorListResource(MethodResource):
     @doc(tags=['predictors'], summary='Get list of predictors.',)
     @marshal_with(PredictorSchema(many=True))
     @use_kwargs({
-        'run_id': wa.fields.DelimitedList(fields.Int(),
-                                          description="Run id(s)"),
+        'dataset_id': wa.fields.DelimitedList(
+            fields.Int(), description="Dataset id(s). If set, ignores run ids"),
+        'run_id': wa.fields.DelimitedList(
+            fields.Int(), description="Run id(s). Warning, slow query."),
         'name': wa.fields.DelimitedList(fields.Str(),
                                         description="Predictor name(s)"),
         'newest': wa.fields.Boolean(missing=True,
@@ -64,8 +66,14 @@ class PredictorListResource(MethodResource):
         else:
             predictor_ids = db.session.query(Predictor.id)
 
+        if 'dataset_id' in kwargs:
+            dataset_id = kwargs.pop('dataset_id')
+            kwargs.pop('run_id')
+            predictor_ids.filter(Predictor.dataset_id.in_(dataset_id))
+            
         if 'run_id' in kwargs:
             run_id = kwargs.pop('run_id')
+            # This following JOIN is quite slow
             predictor_ids = predictor_ids.join(PredictorEvent).filter(
                 PredictorEvent.run_id.in_(run_id))
 

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -68,9 +68,9 @@ class PredictorListResource(MethodResource):
 
         if 'dataset_id' in kwargs:
             dataset_id = kwargs.pop('dataset_id')
-            kwargs.pop('run_id')
+            if 'run_id' in kwargs: kwargs.pop('run_id')
             predictor_ids.filter(Predictor.dataset_id.in_(dataset_id))
-            
+
         if 'run_id' in kwargs:
             run_id = kwargs.pop('run_id')
             # This following JOIN is quite slow

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -10,6 +10,7 @@ class ExtractedFeatureSchema(Schema):
     id = fields.Int(description="Extractor id")
     description = fields.Str(description="Feature description.")
     created_at = fields.Str(description="Extraction timestamp.")
+    extractor_name = fields.Str(description="Extractor name.")
 
 class PredictorSchema(Schema):
     id = fields.Int()

--- a/neuroscout/resources/utils.py
+++ b/neuroscout/resources/utils.py
@@ -25,11 +25,11 @@ def first_or_404(query):
 
 def update_analysis_status(analysis, commit=True):
     """ Checks celery for updates to analysis status and results """
-    if not analysis.status in ["DRAFT", "PASSED"]:
+    if not analysis.status in ["DRAFT", "PASSED", "SUBMITTING"]:
         res = celery_app.AsyncResult(analysis.celery_id)
         if res.state == states.FAILURE:
             analysis.status = "FAILED"
-            analysis.compile_traceback = res.traceback 
+            analysis.compile_traceback = res.traceback
         elif res.state == states.SUCCESS:
             analysis = put_record(res.result, analysis, commit=commit)
             analysis.status = "PASSED"

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -26,7 +26,9 @@ def test_get_predictor(auth_client, extract_features):
     # Test parameters
     ds = decode_json(
         auth_client.get('/api/datasets'))
+    dataset_id = ds[0]['id']
     run_id = str(ds[0]['runs'][0]['id'])
+
     resp = auth_client.get('/api/predictors', params={'run_id' : run_id})
     assert resp.status_code == 200
     pred_select = decode_json(resp)
@@ -35,6 +37,13 @@ def test_get_predictor(auth_client, extract_features):
     resp = auth_client.get('/api/predictors', params={'run_id' : '123123'})
     assert resp.status_code == 200
     assert len(decode_json(resp)) == 0
+
+    # Test filtering by dataset
+    resp = auth_client.get('/api/predictors', params={'dataset_id' : dataset_id})
+    assert resp.status_code == 200
+    pred_select = decode_json(resp)
+    assert type(pred_select) == list
+    assert len(pred_select) == 4
 
     # Test filtering by multiple parameters
     resp = auth_client.get('/api/predictors', params={'name': 'rt',
@@ -76,4 +85,3 @@ def test_get_predictor_data(auth_client, add_task):
     assert resp.status_code == 200
     pe_list_filt = decode_json(resp)
     assert len(pe_list_filt) == 4
-    assert pe_list_filt[0]['duration'] == 5


### PR DESCRIPTION
This PR attempts to work around #239, and the generally slowness of submitting an analysis for compilation.

The issue is that the query is slow to get the PredictorEvents required for writing out bundle / compiling. We could run this query in Celery, but setting up Celery to be aware of SQLAlchemy, Flask + models is a pain, and requires a lot of restructuring.

An easy solution, is to simply have a status "Submitting" which is true after a user has clicked compile, but before the query has finished and the task has been submitted to Celery.

This way, the frontend can just stop caring about the response to `/compile` and instead just poll `/status` to see how the analysis is getting on. This may cause problems with scalability, but we can deal with that problem later, if we are that successful. 