### PR TITLE
Speed up /compile route

### DIFF
--- a/neuroscout/requirements.txt
+++ b/neuroscout/requirements.txt
@@ -28,7 +28,7 @@ ipython==6.2.1
 itsdangerous==0.24
 Jinja2==2.9.6
 MarkupSafe==1.0
-marshmallow==2.13.5
+marshmallow==2.15.3
 moviepy==0.2.3.2
 nibabel==2.1.0
 nltk==3.2.2


### PR DESCRIPTION
Despite efforts to speed up the `/compile` route, it was still taking too long and potentially timing out.

The two bottlenecks where: SQLAlchemy ORM and Marshmallow on up to millions of rows.

Thus, I moved to using core SQLAlchemy,  and manually serializing the results using a custom function. 
This leads to a speed up of almost an order of magnitude (probably ~5-7x) faster on average.

Downsides is we are relying on the order of columns, but this seems to be guaranteed by SQLAlchemy.