### PR TITLE
Updated extractor descriptions

### DIFF
--- a/neuroscout/config/feature_schema.json
+++ b/neuroscout/config/feature_schema.json
@@ -3,7 +3,7 @@
     {
       "features": {
         "brightness$": {
-          "description": "Brightness of an image."
+          "description": "Average luminosity of the pixels"
         }
       }
     }
@@ -12,7 +12,7 @@
     {
       "features": {
         "vibrance$": {
-          "description": "Brightness of an image."
+          "description": "Variance of color channels"
         }
       }
     }
@@ -21,7 +21,7 @@
     {
       "features": {
         "sharpness$": {
-          "description": "Brightness of an image."
+          "description": "Degree of blur/sharpness of the image"
         }
       }
     }
@@ -30,14 +30,14 @@
     {
       "features": {
         "max_saliency$" : {
-          "description": "Maximum salience in image."
+          "description": "Maximum saliency of the image using Itti & Koch (1998) algorithm"
         },
         "max_y$": {
           "description": "Y coord of maximum salience.",
           "active": false
         },
         "max_x$": {
-          "description": "Y coord of maximum salience.",
+          "description": "X coord of maximum salience.",
           "active": false
         },
         "frac_high_saliency$": {
@@ -51,7 +51,7 @@
       "attributes": { "model_name": "general-v1.3" },
       "features": {
         "(.*)": {
-          "description": "General model label class: (\\1)"
+          "description": "Clarifai image recognition label //1"
         }
       }
     },
@@ -59,7 +59,7 @@
       "attributes": { "model_name": "nsfw-v1.0" },
       "features": {
         "nsfw$": {
-          "description": "Probability of nudity"
+          "description": "Likelihood of nudity"
         }
       }
     }
@@ -105,7 +105,7 @@
     {
       "features": {
         "(.*)": {
-          "description": "Audio power at frequency band //1 Hz."
+          "description": "Audio power at frequency band //1 Hz"
         }
       }
     }
@@ -114,7 +114,7 @@
     {
       "features": {
         "mean_amplitude": {
-          "description": "Mean audio amplitude during speech."
+          "description": "Mean audio amplitude during speech"
         }
       }
     }
@@ -123,7 +123,7 @@
     {
       "features": {
         "spectral_centroid": {
-          "description": "Spectral centroids from audio."
+          "description": "Spectral centroids from audio"
         }
       }
     }
@@ -132,7 +132,7 @@
     {
       "features": {
         "rmse": {
-          "description": "Root mean square (RMS) energy from audio."
+          "description": "Root mean square (RMS) energy from audio"
         }
       }
     }
@@ -140,51 +140,51 @@
   "GoogleVisionAPIFaceExtractor": [
     {
       "features": {
-        "face([0-9]*)_boundingPoly_vertex([0-9])_([xy])": {
+        "boundingPoly_vertex([0-9])_([xy])": {
           "description": "Bounding polygon around face. \\3 coordinate for vertex \\2",
           "active": false
         },
-        "face([0-9]*)_fdboundingPoly_vertex([0-9])_([xy])": {
+        "fdboundingPoly_vertex([0-9])_([xy])": {
           "description": "Tight bounding polygon around face. \\3 coordinate for vertex \\2",
           "active": false
         },
-        "face([0-9]*)_landmark_([A-Z])_[xyz]": {
+        "landmark_([A-Z])_[xyz]": {
           "description": "\\3 coordinate for \\2"
         },
-        "face([0-9]*)_rollAngle": {
+        "rollAngle": {
           "description": "Clockwise/anti-clockwise rotation of the face relative to the image vertical about the axis perpendicular to the face"
         },
-        "face([0-9]*)_panAngle": {
+        "panAngle": {
           "description": "Yaw angle, which indicates the leftward/rightward angle that the face is pointing relative to the vertical plane perpendicular to the image"
         },
-        "face([0-9]*)_tiltAngle": {
+        "tiltAngle": {
           "description": "Pitch angle, which indicates the upwards/downwards angle that the face is pointing relative to the image's horizontal plane"
         },
-        "face([0-9]*)_detectionConfidence": {
+        "detectionConfidence": {
           "description": "Face detection confidence"
         },
-        "face([0-9]*)_landmarkingConfidence": {
+        "landmarkingConfidence": {
           "description": "Face landmarking confidence"
         },
-        "face([0-9]*)_joyLikelihood": {
+        "joyLikelihood": {
           "description": "Joy likelihood."
         },
-        "face([0-9]*)_sorrowLikelihood": {
+        "sorrowLikelihood": {
           "description": "Sorrow likelihood."
         },
-        "face([0-9]*)_angerLikelihood": {
+        "angerLikelihood": {
           "description": "Anger likelihood"
         },
-        "face([0-9]*)_surpriseLikelihood": {
+        "surpriseLikelihood": {
           "description": "Surprise likelihood"
         },
-        "face([0-9]*)_underExposedLikelihood": {
+        "underExposedLikelihood": {
           "description": "Under-exposed likelihood."
         },
-        "face([0-9]*)_blurredLikelihood": {
-          "description": "Blurred likelihood"
+        "blurredLikelihood": {
+          "description" : "Blurred likelihood"
         },
-        "face([0-9]*)_headwearLikelihood": {
+        "headwearLikelihood": {
           "description": "Headwear likelihood"
         }
       }
@@ -204,7 +204,7 @@
     {
       "features": {
         ".*": {
-          "description": "RGB Channel.",
+          "description": "RGB Channel",
           "active": false
         }
       }
@@ -214,16 +214,19 @@
     {
       "features": {
         "adult": {
-          "description": "Likelihood of nudity, pornographic images or cartoons, or sexual activities."
+          "description": "Likelihood of nudity, pornographic images or cartoons, or sexual activities"
         },
         "spoof": {
           "description": "Likelihood that an modification was made to the image's canonical version to make it appear funny or offensive"
         },
         "medical": {
-          "description": "Likelihood that this is a medical image."
+          "description": "Likelihood that this is a medical image"
         },
         "violence": {
-          "description": "Likelihood that this image contains violent content."
+          "description": "Likelihood that this image contains violent content"
+        },
+        "racy": {
+          "description": "Likelihood that this image contains racy content"
           }
       }
 
@@ -233,16 +236,16 @@
     {
       "features": {
         "sentiment_compound": {
-          "description": "Overall valence."
+          "description": "Overall valence"
         },
         "sentiment_neu": {
-          "description": "Neutral sentiment."
+          "description": "Neutral sentiment"
         },
         "sentiment_pos": {
-          "description": "Positive sentiment."
+          "description": "Positive sentiment"
         },
         "sentiment_neg": {
-          "description": "Negative sentiment."
+          "description": "Negative sentiment"
         }
       }
 
@@ -261,7 +264,7 @@
     {
       "features": {
         "subtlexusfrequency_Lg10WF": {
-          "description": "log10(FREQcount+1), where FREQcount is the number of times the word appears in the corpus (i.e., on the total of 51 million words)"
+          "description": "Lexical frequency of words in corpus of 51 million words (log)"
         }
       }
     }

--- a/neuroscout/config/feature_schema.json
+++ b/neuroscout/config/feature_schema.json
@@ -141,11 +141,11 @@
     {
       "features": {
         "boundingPoly_vertex([0-9])_([xy])": {
-          "description": "Bounding polygon around face. \\3 coordinate for vertex \\2",
+          "description": "Bounding polygon around face. \\2 coordinate for vertex \\1",
           "active": false
         },
         "fdboundingPoly_vertex([0-9])_([xy])": {
-          "description": "Tight bounding polygon around face. \\3 coordinate for vertex \\2",
+          "description": "Tight bounding polygon around face. \\2 coordinate for vertex \\1",
           "active": false
         },
         "landmark_([A-Z])_[xyz]": {
@@ -186,6 +186,9 @@
         },
         "headwearLikelihood": {
           "description": "Headwear likelihood"
+        },
+        "num_faces": {
+          "description": "Number of detected faces in scene"
         }
       }
     }
@@ -265,6 +268,33 @@
       "features": {
         "subtlexusfrequency_Lg10WF": {
           "description": "Lexical frequency of words in corpus of 51 million words (log)"
+        }
+      }
+    }
+  ],
+  "ComplexTextExtractor":[
+    {
+      "features": {
+        "speech": {
+          "description": "Speech (binarized, on or off)"
+        }
+      }
+    }
+  ],
+  "GoogleVideoAPIShotDetectionExtractor":[
+    {
+      "features": {
+        "shot_change": {
+          "description": "Transitions between scene cuts in video"
+        }
+      }
+    }
+  ],
+  "GoogleVisionAPIPropertyExtractor":[
+    {
+      "features": {
+        "num_colors_0_07": {
+          "description": "Number of colors that occupy more than 7% of pixels"
         }
       }
     }

--- a/neuroscout/config/feature_schema.json
+++ b/neuroscout/config/feature_schema.json
@@ -200,7 +200,6 @@
           "description": "Confidence of image class \\1"
         }
       }
-
     }
   ],
   "GoogleVisionAPIPropertyExtractor": [
@@ -209,6 +208,9 @@
         ".*": {
           "description": "RGB Channel",
           "active": false
+        },
+        "num_colors_0_07": {
+          "description": "Number of colors that occupy more than 7% of pixels"
         }
       }
     }
@@ -286,15 +288,6 @@
       "features": {
         "shot_change": {
           "description": "Transitions between scene cuts in video"
-        }
-      }
-    }
-  ],
-  "GoogleVisionAPIPropertyExtractor":[
-    {
-      "features": {
-        "num_colors_0_07": {
-          "description": "Number of colors that occupy more than 7% of pixels"
         }
       }
     }

--- a/neuroscout/models/features.py
+++ b/neuroscout/models/features.py
@@ -14,6 +14,7 @@ class ExtractedFeature(db.Model):
 	description = db.Column(db.String)
 	active = db.Column(db.Boolean)
 	modality = db.Column(db.String)
+	transformed = db.Column(db.Boolean, default=False)
 
 	created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
 	extractor_version = db.Column(db.Float, default=0.1)

--- a/neuroscout/populate/modify.py
+++ b/neuroscout/populate/modify.py
@@ -96,11 +96,9 @@ def update_annotations(mode='predictors', **kwargs):
     elif mode == 'features':
         schema = json.load(open(current_app.config['FEATURE_SCHEMA']))
         ext_name = kwargs.pop('extractor_name') if 'extractor_name' in kwargs else None
-
         for extractor_name, args in schema.items():
-            if ext_name is not None and ext_name != 'extractor_name':
+            if ext_name is not None and ext_name != extractor_name:
                 break
-
             candidate_efs = ExtractedFeature.query.filter_by(
                 extractor_name=extractor_name, **kwargs)
 
@@ -111,7 +109,7 @@ def update_annotations(mode='predictors', **kwargs):
                         ExtractedFeature.original_name.op("~")(pattern))
                     for match in matching:
                         match.feature_name = re.sub(pattern, attr['name'], match.original_name) \
-                            if 'name' in attr else match.name
+                            if 'name' in attr else match.feature_name
                         match.description = re.sub(pattern, attr['description'], match.original_name) \
                             if 'description' in attr else None
                         for pred in match.generated_predictors:

--- a/neuroscout/populate/modify.py
+++ b/neuroscout/populate/modify.py
@@ -98,7 +98,7 @@ def update_annotations(mode='predictors', **kwargs):
         ext_name = kwargs.pop('extractor_name') if 'extractor_name' in kwargs else None
         for extractor_name, args in schema.items():
             if ext_name is not None and ext_name != extractor_name:
-                break
+                continue
             candidate_efs = ExtractedFeature.query.filter_by(
                 extractor_name=extractor_name, **kwargs)
 


### PR DESCRIPTION
This PR:

1. Fixes a bug in `update_annotations` that prevent matching to `extractor_name`
2. Updated extractor feature schema descriptions.

Left to do:

- [ ] Update GoogleVision Face API feature descriptions. And think of how to re-add features that were inactive (maybe this needs a helper, otherwise it requires re-creating manually. Could force re-create Predictors for the latest ExtractedFeatures. Also, shouldn't dataset_id be a foreign key for EF?)
- [x] Add annotations to transformed features (e.g. `shot_change`). Maybe can use extractor name _trans in schema, and simple check that after transformations. Would make it easy to update after the fact.