### PR TITLE
Enable SSL/HTTPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ celery_worker/src
 
 nginx/sites-enabled/local
 *.swp
+
+nginx/certs
+nginx/certs-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,10 @@ services:
     build: ./nginx
     ports:
       - "80:80"
+      - "443:443"
     volumes:
+      - ./nginx/certs:/etc/letsencrypt
+      - ./nginx/certs-data:/data/letsencrypt
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/sites-enabled:/etc/nginx/sites-enabled:ro
     volumes_from:
@@ -77,3 +80,5 @@ services:
 
 volumes:
   postgres-data:
+  certs:
+  certs-data:

--- a/neuroscout/frontend/package.json
+++ b/neuroscout/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "version": "0.1.0",
-  "proxy": "http://alpha.neuroscout.org:80",
+  "proxy": "https://alpha.neuroscout.org:80",
   "private": true,
   "dependencies": {
     "@types/antd": "^1.0.0",

--- a/neuroscout/frontend/src/config.ts
+++ b/neuroscout/frontend/src/config.ts
@@ -1,3 +1,3 @@
 export const config =  {
-  'server_url': 'http://alpha.neuroscout.org'
+  'server_url': 'https://alpha.neuroscout.org'
 };

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -73,27 +73,5 @@ http {
         ##
         # include /etc/nginx/conf.d/*.conf;
 
-        include /etc/nginx/sites-enabled/*;
+        include /etc/nginx/sites-enabled/flask_project;
 }
-
-
-#mail {
-#       # See sample authentication script at:
-#       # http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
-#
-#       # auth_http localhost/auth.php;
-#       # pop3_capabilities "TOP" "USER";
-#       # imap_capabilities "IMAP4rev1" "UIDPLUS";
-#
-#       server {
-#               listen     localhost:110;
-#               protocol   pop3;
-#               proxy      on;
-#       }
-#
-#       server {
-#               listen     localhost:143;
-#               protocol   imap;
-#               proxy      on;
-#       }
-#}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -73,5 +73,5 @@ http {
         ##
         # include /etc/nginx/conf.d/*.conf;
 
-        include /etc/nginx/sites-enabled/flask_project;
+        include /etc/nginx/sites-enabled/*;
 }

--- a/nginx/sites-enabled/flask_project
+++ b/nginx/sites-enabled/flask_project
@@ -1,12 +1,17 @@
 server {
 
-    listen 80;
-    server_name http://alpha.neuroscout.org;
+    server_name alpha.neuroscout.org;
     charset utf-8;
+    listen      443           ssl http2;
+    listen [::]:443           ssl http2;
 
     root /neuroscout/frontend/build;
 
-    ssl_protocols TLSv1.3;# Requires nginx >= 1.13.0 else use TLSv1.2
+    ssl_certificate           /etc/letsencrypt/live/alpha.neuroscout.org/fullchain.pem;
+    ssl_certificate_key       /etc/letsencrypt/live/alpha.neuroscout.org/privkey.pem;
+    ssl_trusted_certificate   /etc/letsencrypt/live/alpha.neuroscout.org/chain.pem;
+
+    ssl_protocols TLSv1.2;# Requires nginx >= 1.13.0 else use TLSv1.2
     ssl_prefer_server_ciphers on;
     ssl_dhparam /etc/nginx/dhparam.pem; # openssl dhparam -out /etc/nginx/dhparam.pem 4096
     ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;

--- a/nginx/sites-enabled/ssl_config
+++ b/nginx/sites-enabled/ssl_config
@@ -1,0 +1,10 @@
+server {
+     server_name alpha.neuroscout.org;
+
+     location /.well-known {
+         allow all;
+         root  /data/letsencrypt/;
+     }
+     listen 80;
+
+}


### PR DESCRIPTION
Closes #310 

We use letsencrypt with ACME challenge + certbot to get SSL certificates. 
I used this guide: https://miki725.github.io/docker/crypto/2017/01/29/docker+nginx+letsencrypt.html

Some key information:
 - The certs are stored locally on the server, and are ignored by git. 
 - The certs expire every 90 days. In the future this should be a cronjob that gets new certs.
 
The way it basically works is that the nginx server serves `/etc/letsencrypt` on a regular http connection, and the certbot places some verification information there, for letsencrypt to verfify we have control over the domain.

To get a new certificate, this is the command:
`docker run -it --rm -v /full/path/to/certs:/etc/letsencrypt -v /full/path/to/cert-data:/data/letsencrypt deliverous/certbot certonly --webroot --webroot-path=/data/letsencrypt -d alpha.neuroscout.org`

Nginx then serves the correct info, and SSL certificates are made available for the https route.

It may be necessary to disable `flask_server` in the nginx config file while doing this (to avoid errors with a missing SSL config). But maybe not if the SSL certificate has not yet expired. 