### PR TITLE
Add statistics at the Predictor level

### DIFF
--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -19,7 +19,13 @@ class PredictorSchema(Schema):
     name = fields.Str(description="Predictor name.")
     description = fields.Str(description="Predictor description")
     extracted_feature = fields.Nested('ExtractedFeatureSchema', skip_if=None)
-    source = fields.Str()
+    # source = fields.Str()
+
+    max = fields.Float(description="Maximum value")
+    min = fields.Float(description="Minimum value")
+    mean = fields.Float(description="Mean value")
+    stddev = fields.Float(description="Standard deviation of value")
+    num_na = fields.Int(description="Number of missing values")
 
     @post_dump
     def remove_null_values(self, data):

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -19,7 +19,7 @@ class PredictorSchema(Schema):
     name = fields.Str(description="Predictor name.")
     description = fields.Str(description="Predictor description")
     extracted_feature = fields.Nested('ExtractedFeatureSchema', skip_if=None)
-    # source = fields.Str()
+    source = fields.Str()
 
     max = fields.Float(description="Maximum value")
     min = fields.Float(description="Minimum value")

--- a/neuroscout/scripts/build_static.sh
+++ b/neuroscout/scripts/build_static.sh
@@ -1,3 +1,0 @@
-cd /build/frontend
-yarn install
-yarn build

--- a/neuroscout/scripts/init_reset.sh
+++ b/neuroscout/scripts/init_reset.sh
@@ -1,8 +1,0 @@
-#! /bin/bash
-rm -r /migrations/migrations
-rm -r migrations
-python manage.py db init
-python manage.py db migrate
-python manage.py db upgrade
-
-python manage.py add_user user@example.com string

--- a/neuroscout/scripts/nuke_docker_db.sh
+++ b/neuroscout/scripts/nuke_docker_db.sh
@@ -1,3 +1,0 @@
-docker-compose exec postgres psql -h postgres -U postgres -c "drop database neuroscout"
-docker-compose exec postgres psql -h postgres -U postgres -c "create database neuroscout"
-docker-compose exec neuroscout bash scripts/init_reset.sh

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -12,6 +12,13 @@ def test_get_predictor(auth_client, extract_features):
     assert rt['description'] == "How long it takes to react!"
     pred_id = rt['id']
 
+    # Test auto-calculated properties
+    assert  rt['mean'] == 173.625
+    assert  rt['max'] == 230.0
+    assert  rt['min'] == 120.0
+    assert  round(rt['stddev']) == 41
+    assert  rt['num_na'] == 0
+
     # Check that derivative event is in there
     assert len([p for p in pred_list if p['name'] == 'rating']) > 0
 


### PR DESCRIPTION
Closes #232 
Instead of caching a stored values for PredictorRun values. For now, instead, will add dynamic properties to Predictors which use SQLAlchemy to compute these values. A bit costly, but caching should for the most part solve this issue.