### PR TITLE
API Change: Dump/load flat lists for predictors and runs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,4 +6,4 @@ services:
 
   swagger-ui:
     environment:
-      - "API_URL=https://127.0.0.1/swagger/"
+      - "API_URL=http://localhost/swagger/"

--- a/neuroscout/resources/analysis/schemas.py
+++ b/neuroscout/resources/analysis/schemas.py
@@ -56,7 +56,7 @@ class AnalysisSchema(Schema):
 			raise ValidationError('Invalid predictor id.')
 
 	@pre_load
-	def fix_nesting(self, in_data):
+	def unflatten(self, in_data):
 		if 'runs' in in_data:
 		    in_data['runs'] = [{"id": r} for r in in_data['runs']]
 		if 'predictors' in in_data:

--- a/neuroscout/resources/dataset.py
+++ b/neuroscout/resources/dataset.py
@@ -13,7 +13,7 @@ class DatasetSchema(Schema):
 	summary = fields.Str(description='Dataset summary description')
 	mimetypes = fields.List(fields.Str(),
                          description='Dataset mimetypes/modalities')
-	runs = fields.Nested('RunSchema', many=True, only=['id'])
+	runs = fields.Nested('RunSchema', many=True, only='id')
 	tasks = fields.Nested('TaskSchema', many=True, only=['id', 'name'])
 	dataset_address = fields.Str(description='BIDS Dataset remote address')
 	preproc_address = fields.Str(description='Preprocessed data remote address')

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -88,7 +88,7 @@ class PredictorListResource(MethodResource):
 
 class PredictorEventListResource(MethodResource):
     @doc(tags=['predictors'], summary='Get events for predictor(s)',)
-    @marshal_with(PredictorEventSchema(many=True, exclude=['predictor']))
+    @marshal_with(PredictorEventSchema(many=True))
     @cache.cached(60 * 60 * 24 * 300, key_prefix=make_cache_key)
     @use_kwargs({
         'run_id': wa.fields.DelimitedList(fields.Int(),

--- a/neuroscout/resources/user.py
+++ b/neuroscout/resources/user.py
@@ -90,7 +90,7 @@ class UserTriggerResetResource(MethodResource):
         return {'message' : 'Password reset token sent'}, 200
 
 # @doc(tags=['auth'], summary='Reset user password using a token.')
-@use_kwargs(UserCreationSchema(only=['token', 'password']))
+@use_kwargs(UserResetSchema(only=['token', 'password']))
 class UserResetSubmitResource(MethodResource):
     def post(self, **kwargs):
         expired, invalid, user = reset_password_token_status(kwargs['token'])

--- a/neuroscout/tests/api/test_analyses.py
+++ b/neuroscout/tests/api/test_analyses.py
@@ -202,7 +202,7 @@ def test_put(auth_client, add_analysis, add_task, session):
 	assert new_analysis['runs'] == [{'id' :	Run.query.first().id }]
 
 	# Test adding an invalid run id
-	analysis_json['runs'] = [{'id' : 9999 }]
+	analysis_json['runs'] = [9999]
 
 	resp = auth_client.put('/api/analyses/{}'.format(analysis.hash_id),
 						data=analysis_json)
@@ -221,7 +221,7 @@ def test_put(auth_client, add_analysis, add_task, session):
 	analysis_json = decode_json(resp)
 
 	# Test adding a run_id
-	analysis_json['runs'] = [{'id' : Run.query.first().id }]
+	analysis_json['runs'] = [Run.query.first().id]
 
 	resp = auth_client.put('/api/analyses/{}'.format(analysis_json['hash_id']),
 						data=analysis_json)

--- a/neuroscout/tests/api/test_analyses.py
+++ b/neuroscout/tests/api/test_analyses.py
@@ -193,13 +193,13 @@ def test_put(auth_client, add_analysis, add_task, session):
 	assert new_analysis['name'] == "NEW NAME"
 
 	# Test adding a run_id
-	analysis_json['runs'] = [{'id' : Run.query.first().id }]
+	analysis_json['runs'] = [Run.query.first().id ]
 
 	resp = auth_client.put('/api/analyses/{}'.format(analysis.hash_id),
 						data=analysis_json)
 	assert resp.status_code == 200
 	new_analysis = decode_json(resp)
-	assert new_analysis['runs'] == [{'id' :	Run.query.first().id }]
+	assert new_analysis['runs'] == [Run.query.first().id ]
 
 	# Test adding an invalid run id
 	analysis_json['runs'] = [9999]

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -35,7 +35,7 @@ def test_get_predictor(auth_client, extract_features):
     ds = decode_json(
         auth_client.get('/api/datasets'))
     dataset_id = ds[0]['id']
-    run_id = str(ds[0]['runs'][0]['id'])
+    run_id = str(ds[0]['runs'][0])
 
     resp = auth_client.get('/api/predictors', params={'run_id' : run_id})
     assert resp.status_code == 200


### PR DESCRIPTION
This PR implements a backwards changing API change. Runs and predictors now dump and load with flat lists of ids, rather than lists of objects with "id" as an item. This was original this way due to a marshmallow issue (asymetrical dumping/loading). Looks like this is getting fixed in 3.0, but it's still in beta, and upgrading seems to cause other problems that I rather not deal with now.

Also, I fixed some small schema errors, and the Swagger UI URL for Development mode.