### PR TITLE
Fix bug with auto selected run IDs.

### DIFF
--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -544,8 +544,12 @@ export default class AnalysisBuilder extends React.Component<BuilderProps, Store
             message.success(`Fetched ${data.length} runs associated with the selected dataset`);
             let availTasks = getTasks(data);
             if (availTasks.length === 1) {
-                this.setState({selectedTaskId: availTasks[0].id});
-                updatedAnalysis.runIds = data.map(x => x.id);
+              updatedAnalysis.runIds = data.map(x => x.id);
+              this.setState({
+                selectedTaskId: availTasks[0].id,
+                predictorsLoad: true,
+                predictorsActive: true
+              });
             }
             this.setState({
               availableRuns: data,

--- a/neuroscout/frontend/src/Overview.tsx
+++ b/neuroscout/frontend/src/Overview.tsx
@@ -308,10 +308,9 @@ export class OverviewTab extends React.Component<OverviewTabProps, OverviewTabSt
               <br />
             </div>}
         </Form>
-        {predictorsActive &&
-          <Button type="primary" onClick={goToNextTab}>
+          <Button type="primary" onClick={goToNextTab} disabled={!predictorsActive}>
             Next: Select Predictors
-          </Button>}
+          </Button>
       </div>
     );
   }


### PR DESCRIPTION
fixes #359

The code added that automatically selects runIds when a dataset is selected happens is a promise and was getting executed after the code that checked to see if new predictors should be loaded. Went ahead and set the flags to load predictors and allow access to the predictors tab.