### PR TITLE
Update pybids to 0.7

### DIFF
--- a/celery_worker/tasks.py
+++ b/celery_worker/tasks.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from tempfile import mkdtemp
 from bids.analysis import Analysis
-from bids.grabbids import BIDSLayout
+from bids.layout import BIDSLayout
 from grabbit import Layout
 from copy import deepcopy
 
@@ -66,7 +66,7 @@ def compile(analysis, predictor_events, resources, bids_dir):
     bundle_paths = writeout_events(analysis, predictor_events, files_dir)
     logger.info(model['input'])
     # Load events and try applying transformations
-    bids_layout = BIDSLayout([(bids_dir, 'bids'), (files_dir.as_posix(), ['bids', 'derivatives'])], exclude='derivatives/')
+    bids_layout = BIDSLayout([(bids_dir, 'bids'), (files_dir.as_posix(), 'derivatives')])
     bids_analysis = Analysis(bids_layout, deepcopy(model))
     bids_analysis.setup(**kwargs)
 

--- a/neuroscout/manage.py
+++ b/neuroscout/manage.py
@@ -49,18 +49,16 @@ def add_user(email, password, confirm=True):
     db.session.commit()
 
 @manager.command
-def add_task(local_path, task, automagic=False,
-             skip_predictors=False, filters='{}'):
+def add_task(local_path, task, skip_predictors=False, filters='{}'):
     """ Add BIDS dataset to database.
     local_path - Path to local_path directory
     task - Task name
-    automagic - Force enable datalad automagic
     skip_predictors - Skip original Predictors
     filters - string JSON object with optional run filters
     """
     populate.add_task(
         task, local_path=local_path, skip_predictors=skip_predictors,
-        automagic=automagic, **json.loads(filters))
+        **json.loads(filters))
 
 @manager.command
 def extract_features(local_path, task, graph_spec, filters='{}'):
@@ -74,14 +72,13 @@ def extract_features(local_path, task, graph_spec, filters='{}'):
         local_path, task, graph_spec, **json.loads(filters))
 
 @manager.command
-def ingest_from_json(config_file, automagic=False, update_features=False,
-                     reingest=False):
+def ingest_from_json(config_file, update_features=False, reingest=False):
     """ Ingest/update datasets and extracted features from a json config file.
     config_file - json config file detailing datasets and pliers graph_json
     automagic - Force enable datalad automagic
     """
     populate.ingest_from_json(
-        config_file, automagic=automagic, update_features=update_features,
+        config_file, update_features=update_features,
         reingest=reingest)
 
 if __name__ == '__main__':

--- a/neuroscout/populate/ingest.py
+++ b/neuroscout/populate/ingest.py
@@ -218,7 +218,7 @@ def add_task(task_name, dataset_name=None, local_path=None,
             run_model.duration = scan_length
 
         path_patterns = ['sub-{subject}[ses-{session}/]/func/sub-{subject}_'
-                         '[ses-{session}_]task-{task}_[acq-{acquisition}_]'
+                         '[ses-{session}_]task-{task}_[acquisition-{acquisition}_]'
                          '[run-{run}_]bold_[space-{space}_]{suffix}.nii.gz']
 
         if 'run' in 'entities':

--- a/neuroscout/populate/ingest.py
+++ b/neuroscout/populate/ingest.py
@@ -117,7 +117,7 @@ def add_stimulus(stim_hash, dataset_id, parent_id=None, path=None, content=None,
 
 def add_task(task_name, dataset_name=None, local_path=None,
              dataset_address=None, preproc_address=None, include_predictors=None,
-             reingest=False, scan_length=1000, automagic=False, summary=None, **kwargs):
+             reingest=False, scan_length=1000, summary=None, **kwargs):
     """ Adds a BIDS dataset task to the database.
         Args:
             task_name - task to add
@@ -128,7 +128,6 @@ def add_task(task_name, dataset_name=None, local_path=None,
             include_predictors - set of predictors to ingest
             reingest - force reingesting even if dataset already exists
             scan_length - default scan length in case it cant be found in image
-            automagic - force enable DataLad automagic
             kwargs - arguments to filter runs by
         Output:
             dataset model id
@@ -141,12 +140,8 @@ def add_task(task_name, dataset_name=None, local_path=None,
             path=(Path(
                 current_app.config['DATASET_DIR']) / dataset_name).as_posix()
             ).path
-        automagic = True
 
     local_path = Path(local_path)
-    if automagic:
-        automagic = AutomagicIO()
-        automagic.activate()
 
     from os.path import isfile
     assert isfile((local_path / 'dataset_description.json').as_posix())
@@ -174,8 +169,6 @@ def add_task(task_name, dataset_name=None, local_path=None,
         dataset_model.local_path = local_path.as_posix()
         db.session.commit()
     elif not reingest:
-        if automagic:
-            automagic.deactivate()
         return dataset_model.id
 
     # Get or create task
@@ -278,8 +271,5 @@ def add_task(task_name, dataset_name=None, local_path=None,
     """ Add GroupPredictors """
     current_app.logger.info("Adding group predictors")
     add_group_predictors(dataset_model.id, local_path / 'participants.tsv')
-
-    if automagic:
-        automagic.deactivate()
 
     return dataset_model.id

--- a/neuroscout/populate/json.py
+++ b/neuroscout/populate/json.py
@@ -56,12 +56,10 @@ def load_update_config(config_file, update=False):
 
     return config_dict
 
-def ingest_from_json(config_file, automagic=False,
-                     update_features=False, reingest=False):
+def ingest_from_json(config_file, update_features=False, reingest=False):
     """ Adds a datasets from a JSON configuration file
         Args:
             config_file - a path to a json file
-            automagic - force enable DataLad automagic
             update_features - re-extracted updated extractors
             reingest - force reingest dataset
         Output:
@@ -93,7 +91,6 @@ def ingest_from_json(config_file, automagic=False,
                                   dataset_name=dataset_name,
                                   local_path=local_path,
                                   dataset_address=dataset_address,
-                                  automagic=automagic,
                                   preproc_address=preproc_address,
                                   reingest=reingest,
             					  **dp)

--- a/neuroscout/requirements.txt
+++ b/neuroscout/requirements.txt
@@ -46,7 +46,7 @@ psycopg2==2.7.1
 progressbar2
 py==1.4.33
 grabbit==0.2.3
-pybids==0.6.5
+-e git+https://github.com/INCF/pybids.git@lets-break-stuff#egg=pybids
 PyJWT==1.4.2
 pyparsing==2.2.0
 pytest==3.0.7

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -69,46 +69,6 @@ def test_dataset_ingestion(session, add_task):
 	assert gpv.count() == 4
 	assert 'F' in [v.value for v in gpv]
 
-@pytest.mark.skipif(os.environ.get("TRAVIS") == "true",
-	reason="Skipping this test on Travis CI.")
-def test_remote_dataset(session, add_task_remote):
-	dataset_model = Dataset.query.filter_by(id=add_task_remote).one()
-
-	# Test mimetypes
-	assert 'image/jpeg' in dataset_model.mimetypes
-	assert 'bidstest' == dataset_model.tasks[0].name
-
-	# Test properties of Run
-	assert Run.query.filter_by(dataset_id=add_task_remote).count() \
-			== dataset_model.runs.count() == 1
-	predictor = Predictor.query.filter_by(name='rt').first()
-	assert predictor.predictor_events.count() == 4
-
-	# Test that Stimiuli were extracted
-	assert Stimulus.query.count() == 5
-
-	# Test participants.tsv ingestion
-	assert GroupPredictor.query.filter_by(
-			dataset_id=add_task_remote).count() == 3
-
-	fre = ExtractedFeature.query.filter_by(
-		extractor_name='FaceRecognitionFaceLandmarksExtractor')
-
-	assert fre.count() == 9
-	fre_ids = [ef.id for ef in fre]
-
-	ef = ExtractedFeature.query.filter_by(
-			extractor_name='FaceRecognitionFaceLandmarksExtractor',
-			feature_name='face_landmarks_bottom_lip').first()
-
-	assert ef.extracted_events.count() == 5
-
-	# Test that predictor was made, (only this feature should be active)
-	preds = Predictor.query.filter(Predictor.ef_id.in_(fre_ids))
-	assert preds.count() == 1
-
-	assert preds.first().predictor_events.count() == 5
-
 def test_json_local_dataset(session, add_local_task_json):
 	dataset_model = Dataset.query.filter_by(id=add_local_task_json).one()
 


### PR DESCRIPTION
Closes #367 

TODO:
 - Since `exclude` is being deprecated we need a way to specific which event files to look for in `fitlins` (see: https://github.com/neuroscout/neuroscout-cli/issues/52). This may require changing the file names for bundle files.