### PR TITLE
Menu/tab UI overhaul

### DIFF
--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -401,9 +401,12 @@ class App extends Reflux.Component<any, {}, AppState> {
                 >
                   <Menu.Item key="home">
                     <span className="nav-text" style={{fontSize: 20}}>Neuroscout</span></Menu.Item>
-                    
+
                   {this.state.auth.loggedIn ?
-                    <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="circle" icon="user" />}>
+                    <Menu.SubMenu
+                      style={{float: 'right'}}
+                      title={<Avatar shape="circle" icon="user" />}
+                    >
                        <Menu.ItemGroup title={`${email}`}>
                          <Menu.Item
                           key="mine"
@@ -423,11 +426,11 @@ class App extends Reflux.Component<any, {}, AppState> {
                           Sign Out
                          </Menu.Item>
                        </Menu.ItemGroup>
-                     </Menu.SubMenu>
-                     :
-                      <Menu.Item key="signup" style={{float: 'right'}} disabled="true">
-                      <Button size="large" type="primary" onClick={e => authActions.update({ openSignup: true })}>
-                        Sign up</Button></Menu.Item>
+                    </Menu.SubMenu>
+                   :
+                    <Menu.Item key="signup" style={{float: 'right'}} disabled="true">
+                    <Button size="large" type="primary" onClick={e => authActions.update({ openSignup: true })}>
+                      Sign up</Button></Menu.Item>
                    }
                    {this.state.auth.loggedIn === false &&
                        <Menu.Item

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -398,6 +398,7 @@ class App extends Reflux.Component<any, {}, AppState> {
                 <Menu
                   mode="horizontal"
                   style={{ lineHeight: '64px'}}
+                  selectedKeys={[]}
                 >
                   <Menu.Item key="home">
                      <Link to="/" style={{fontSize: 20}}>Neuroscout</Link></Menu.Item>

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -393,34 +393,29 @@ class App extends Reflux.Component<any, {}, AppState> {
           <Layout>
 
             <Content style={{ background: '#fff' }}>
-            <Row type="flex" justify="center" style={{ padding: 0 }}>
+            <Row type="flex" justify="center" style={{padding: 0 }}>
               <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
                 <Menu
                   mode="horizontal"
-                  style={{ lineHeight: '60px'}}
+                  style={{ lineHeight: '64px'}}
                 >
                   <Menu.Item key="home">
                     <span className="nav-text" style={{fontSize: 20}}>Neuroscout</span></Menu.Item>
-                    {this.state.auth.loggedIn &&
-                      <Menu.Item key="create" >
-                        <Link to="/builder">
-                        <Icon type="plus" />
-                        Build Analysis</Link></Menu.Item>
-                    }
-                    {this.state.auth.loggedIn &&
-                      <Menu.Item key="mine">
-                      <Link to="/">
-                        <Icon type="bars" />
-                      My Analyses</Link></Menu.Item>
-                    }
-                    <Menu.Item key="browse">
-                    <Link to="/browse">
-                      <Icon type="search"/>
-                      Browse</Link></Menu.Item>
-
+                    
                   {this.state.auth.loggedIn ?
                     <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="circle" icon="user" />}>
                        <Menu.ItemGroup title={`${email}`}>
+                         <Menu.Item
+                          key="mine"
+                         >
+                          My Analyses
+                         </Menu.Item>
+                         <Menu.Item
+                          key="profile"
+                         >
+                          My Profile
+                         </Menu.Item>
+                         <Menu.Divider/>
                          <Menu.Item
                           key="signout"
                           onClick={(e) => {return authActions.confirmLogout(); }}
@@ -445,6 +440,18 @@ class App extends Reflux.Component<any, {}, AppState> {
                     }
                    <Menu.Item  style={{float: 'right'}} key="help">
                      <Icon type="question-circle" /><span className="nav-text">Help</span></Menu.Item>
+
+                     <Menu.Item key="browse" style={{float: 'right'}}>
+                     <Link to="/browse">
+                       <Icon type="search"/>
+                       Browse</Link></Menu.Item>
+                   {this.state.auth.loggedIn &&
+                     <Menu.Item key="create" style={{float: 'right'}}>
+                       <Link to="/builder">
+                       <Icon type="plus" />
+                       New Analysis</Link></Menu.Item>
+                   }
+
                 </Menu>
               </Col>
             </Row>

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -391,6 +391,19 @@ class App extends Reflux.Component<any, {}, AppState> {
           {openSignup && signupModal()}
           {openEnterResetToken && authActions.enterResetTokenModal()}
           <Layout>
+           <Header>
+             <Link to="/">Neuroscout</Link>
+             <Menu
+                theme="dark"
+                mode="horizontal"
+                defaultSelectedKeys={['2']}
+                style={{ lineHeight: '64px' }}
+              >
+                <Menu.Item key="1">nav 1</Menu.Item>
+                <Menu.Item key="2">nav 2</Menu.Item>
+                <Menu.Item key="3">nav 3</Menu.Item>
+              </Menu>
+            </Header>
             <Row type="flex" justify="center"style={{ background: '#fff', padding: 0 }}>
                 <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
                   <div className="headerRow">
@@ -399,7 +412,7 @@ class App extends Reflux.Component<any, {}, AppState> {
                       ? <span>
                           {`${email}`}
                           <Space />
-                          <Button 
+                          <Button
                             onClick={(e) => {
                               return authActions.confirmLogout();
                             }}
@@ -462,7 +475,7 @@ class App extends Reflux.Component<any, {}, AppState> {
                 exact={true}
                 path="/browse/:id"
                 render={props =>
-                  <AnalysisBuilder 
+                  <AnalysisBuilder
                     id={props.match.params.id}
                     updatedAnalysis={() => this.loadAnalyses()}
                   />

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -346,7 +346,7 @@ class App extends Reflux.Component<any, {}, AppState> {
         <Form
           onSubmit={e => {
             e.preventDefault();
-            authActions.signup();
+            authActions.signUp();
           }}
         >
           <FormItem>

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -7,7 +7,7 @@ Top-level App component containing AppState. The App component is currently resp
 import * as React from 'react';
 import { BrowserRouter as Router, Route, Link, Redirect } from 'react-router-dom';
 import Reflux from 'reflux';
-import { Tabs, Row, Col, Layout, Button, Modal, Icon, Input, Form, message } from 'antd';
+import { Avatar, Tabs, Row, Col, Layout, Button, Modal, Menu, Icon, Input, Form, message } from 'antd';
 
 import './App.css';
 import AnalysisBuilder from './Builder';
@@ -24,7 +24,7 @@ const FormItem = Form.Item;
 const DOMAINROOT = config.server_url;
 const { localStorage } = window;
 
-const { Footer, Content, Header } = Layout;
+const { Header, Content, Footer, Sider } = Layout;
 
 interface AppState {
   loadAnalyses: boolean;
@@ -391,52 +391,40 @@ class App extends Reflux.Component<any, {}, AppState> {
           {openSignup && signupModal()}
           {openEnterResetToken && authActions.enterResetTokenModal()}
           <Layout>
-           <Header>
-             <Link to="/">Neuroscout</Link>
-             <Menu
+
+          <Header>
+              <div className="logo" />
+              <Menu
                 theme="dark"
                 mode="horizontal"
-                defaultSelectedKeys={['2']}
+                defaultSelectedKeys={['1']}
                 style={{ lineHeight: '64px' }}
               >
-                <Menu.Item key="1">nav 1</Menu.Item>
-                <Menu.Item key="2">nav 2</Menu.Item>
-                <Menu.Item key="3">nav 3</Menu.Item>
+                <Menu.Item key="home">
+                  <span className="nav-text" style={{fontSize: 20}}>
+                  Neuroscout</span></Menu.Item>
+                <Menu.Item key="create">
+                  <Icon type="plus" />
+                  <span className="nav-text">Create Analysis</span></Menu.Item>
+                <Menu.Item key="mine">
+                  <Icon type="bars" />
+                  <span className="nav-text">My Analyses</span></Menu.Item>
+
+                <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="square" icon="user" />}>
+                   <Menu.ItemGroup title="email@email.com">
+                     <Menu.Item key="profile">My Profile</Menu.Item>
+                     <Menu.Item key="signout">Sign Out</Menu.Item>
+                   </Menu.ItemGroup>
+                 </Menu.SubMenu>
+                 <Menu.Item style={{float: 'right'}} key="browse">
+                   <Icon type="search" />
+                   <span className="nav-text">Browse</span></Menu.Item>
+                 <Menu.Item  style={{float: 'right'}} key="help">
+                   <Icon type="question-circle" /><span className="nav-text">Help</span></Menu.Item>
               </Menu>
             </Header>
-            <Row type="flex" justify="center"style={{ background: '#fff', padding: 0 }}>
-                <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
-                  <div className="headerRow">
-                    <div className="Login-col">
-                    {this.state.auth.loggedIn
-                      ? <span>
-                          {`${email}`}
-                          <Space />
-                          <Button
-                            onClick={(e) => {
-                              return authActions.confirmLogout();
-                            }}
-                          >
-                            Log out
-                          </Button>
-                        </span>
-                      : <span>
-                          <Button onClick={e => authActions.update({ openLogin: true })}>
-                            Log in
-                          </Button>
-                          <Space />
-                          <Button onClick={e => authActions.update({ openSignup: true })}>
-                            Sign up
-                          </Button>
-                        </span>}
-                    </div>
-                    <h1>
-                      <Link to="/">Neuroscout</Link>
-                    </h1>
-                    </div>
-                  </Col>
-              </Row>
             <Content style={{ background: '#fff' }}>
+              <br />
               <Route
                 exact={true}
                 path="/"

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -393,32 +393,32 @@ class App extends Reflux.Component<any, {}, AppState> {
           <Layout>
 
             <Content style={{ background: '#fff' }}>
-            <Row type="flex" justify="center">
+            <Row type="flex" justify="center" style={{ background: '#001529' }}>
               <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
                 <Menu
                   mode="horizontal"
                   defaultSelectedKeys={['1']}
                   style={{ lineHeight: '64px'}}
+                  theme="dark"
                 >
                   <Menu.Item key="home">
-                    <span className="nav-text" style={{fontSize: 20}}>
+                    <span className="nav-text" style={{fontSize: 21}}>
                     Neuroscout</span></Menu.Item>
                   <Menu.Item key="create">
                     <Icon type="plus" />
-                    <span className="nav-text">Create Analysis</span></Menu.Item>
+                    <span className="nav-text">Build Analysis</span></Menu.Item>
                   <Menu.Item key="mine">
                     <Icon type="bars" />
                     <span className="nav-text">My Analyses</span></Menu.Item>
+                    <Menu.Item key="browse">
+                      <Icon type="search"/>
+                      <span className="nav-text">Browse</span></Menu.Item>
 
-                  <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="square" icon="user" />}>
+                  <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="circle" icon="user" />}>
                      <Menu.ItemGroup title="email@email.com">
-                       <Menu.Item key="profile">My Profile</Menu.Item>
                        <Menu.Item key="signout">Sign Out</Menu.Item>
                      </Menu.ItemGroup>
                    </Menu.SubMenu>
-                   <Menu.Item style={{float: 'right'}} key="browse">
-                     <Icon type="search" />
-                     <span className="nav-text">Browse</span></Menu.Item>
                    <Menu.Item  style={{float: 'right'}} key="help">
                      <Icon type="question-circle" /><span className="nav-text">Help</span></Menu.Item>
                 </Menu>

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -393,32 +393,56 @@ class App extends Reflux.Component<any, {}, AppState> {
           <Layout>
 
             <Content style={{ background: '#fff' }}>
-            <Row type="flex" justify="center" style={{ background: '#001529' }}>
+            <Row type="flex" justify="center" style={{ padding: 0 }}>
               <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
                 <Menu
                   mode="horizontal"
-                  defaultSelectedKeys={['1']}
-                  style={{ lineHeight: '64px'}}
-                  theme="dark"
+                  style={{ lineHeight: '60px'}}
                 >
                   <Menu.Item key="home">
-                    <span className="nav-text" style={{fontSize: 21}}>
-                    Neuroscout</span></Menu.Item>
-                  <Menu.Item key="create">
-                    <Icon type="plus" />
-                    <span className="nav-text">Build Analysis</span></Menu.Item>
-                  <Menu.Item key="mine">
-                    <Icon type="bars" />
-                    <span className="nav-text">My Analyses</span></Menu.Item>
+                    <span className="nav-text" style={{fontSize: 20}}>Neuroscout</span></Menu.Item>
+                    {this.state.auth.loggedIn &&
+                      <Menu.Item key="create" >
+                        <Link to="/builder">
+                        <Icon type="plus" />
+                        Build Analysis</Link></Menu.Item>
+                    }
+                    {this.state.auth.loggedIn &&
+                      <Menu.Item key="mine">
+                      <Link to="/">
+                        <Icon type="bars" />
+                      My Analyses</Link></Menu.Item>
+                    }
                     <Menu.Item key="browse">
+                    <Link to="/browse">
                       <Icon type="search"/>
-                      <span className="nav-text">Browse</span></Menu.Item>
+                      Browse</Link></Menu.Item>
 
-                  <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="circle" icon="user" />}>
-                     <Menu.ItemGroup title="email@email.com">
-                       <Menu.Item key="signout">Sign Out</Menu.Item>
-                     </Menu.ItemGroup>
-                   </Menu.SubMenu>
+                  {this.state.auth.loggedIn ?
+                    <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="circle" icon="user" />}>
+                       <Menu.ItemGroup title={`${email}`}>
+                         <Menu.Item
+                          key="signout"
+                          onClick={(e) => {return authActions.confirmLogout(); }}
+                         >
+                          Sign Out
+                         </Menu.Item>
+                       </Menu.ItemGroup>
+                     </Menu.SubMenu>
+                     :
+                      <Menu.Item key="signup" style={{float: 'right'}} disabled="true">
+                      <Button size="large" type="primary" onClick={e => authActions.update({ openSignup: true })}>
+                        Sign up</Button></Menu.Item>
+                   }
+                   {this.state.auth.loggedIn === false &&
+                       <Menu.Item
+                        onClick={e => authActions.update({ openLogin: true })}
+                        key="signin"
+                        style={{float: 'right'}}
+                       >
+                         Sign in
+                       </Menu.Item>
+                    }
                    <Menu.Item  style={{float: 'right'}} key="help">
                      <Icon type="question-circle" /><span className="nav-text">Help</span></Menu.Item>
                 </Menu>

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -392,38 +392,38 @@ class App extends Reflux.Component<any, {}, AppState> {
           {openEnterResetToken && authActions.enterResetTokenModal()}
           <Layout>
 
-          <Header>
-              <div className="logo" />
-              <Menu
-                theme="dark"
-                mode="horizontal"
-                defaultSelectedKeys={['1']}
-                style={{ lineHeight: '64px' }}
-              >
-                <Menu.Item key="home">
-                  <span className="nav-text" style={{fontSize: 20}}>
-                  Neuroscout</span></Menu.Item>
-                <Menu.Item key="create">
-                  <Icon type="plus" />
-                  <span className="nav-text">Create Analysis</span></Menu.Item>
-                <Menu.Item key="mine">
-                  <Icon type="bars" />
-                  <span className="nav-text">My Analyses</span></Menu.Item>
-
-                <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="square" icon="user" />}>
-                   <Menu.ItemGroup title="email@email.com">
-                     <Menu.Item key="profile">My Profile</Menu.Item>
-                     <Menu.Item key="signout">Sign Out</Menu.Item>
-                   </Menu.ItemGroup>
-                 </Menu.SubMenu>
-                 <Menu.Item style={{float: 'right'}} key="browse">
-                   <Icon type="search" />
-                   <span className="nav-text">Browse</span></Menu.Item>
-                 <Menu.Item  style={{float: 'right'}} key="help">
-                   <Icon type="question-circle" /><span className="nav-text">Help</span></Menu.Item>
-              </Menu>
-            </Header>
             <Content style={{ background: '#fff' }}>
+            <Row type="flex" justify="center">
+              <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
+                <Menu
+                  mode="horizontal"
+                  defaultSelectedKeys={['1']}
+                  style={{ lineHeight: '64px'}}
+                >
+                  <Menu.Item key="home">
+                    <span className="nav-text" style={{fontSize: 20}}>
+                    Neuroscout</span></Menu.Item>
+                  <Menu.Item key="create">
+                    <Icon type="plus" />
+                    <span className="nav-text">Create Analysis</span></Menu.Item>
+                  <Menu.Item key="mine">
+                    <Icon type="bars" />
+                    <span className="nav-text">My Analyses</span></Menu.Item>
+
+                  <Menu.SubMenu style={{float: 'right'}} title={<Avatar shape="square" icon="user" />}>
+                     <Menu.ItemGroup title="email@email.com">
+                       <Menu.Item key="profile">My Profile</Menu.Item>
+                       <Menu.Item key="signout">Sign Out</Menu.Item>
+                     </Menu.ItemGroup>
+                   </Menu.SubMenu>
+                   <Menu.Item style={{float: 'right'}} key="browse">
+                     <Icon type="search" />
+                     <span className="nav-text">Browse</span></Menu.Item>
+                   <Menu.Item  style={{float: 'right'}} key="help">
+                     <Icon type="question-circle" /><span className="nav-text">Help</span></Menu.Item>
+                </Menu>
+              </Col>
+            </Row>
               <br />
               <Route
                 exact={true}

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -400,8 +400,7 @@ class App extends Reflux.Component<any, {}, AppState> {
                   style={{ lineHeight: '64px'}}
                 >
                   <Menu.Item key="home">
-                    <span className="nav-text" style={{fontSize: 20}}>Neuroscout</span></Menu.Item>
-
+                     <Link to="/" style={{fontSize: 20}}>Neuroscout</Link></Menu.Item>
                   {this.state.auth.loggedIn ?
                     <Menu.SubMenu
                       style={{float: 'right'}}

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -346,7 +346,7 @@ class App extends Reflux.Component<any, {}, AppState> {
         <Form
           onSubmit={e => {
             e.preventDefault();
-            authActions.signUp();
+            authActions.signup();
           }}
         >
           <FormItem>

--- a/neuroscout/frontend/src/Browse.tsx
+++ b/neuroscout/frontend/src/Browse.tsx
@@ -9,6 +9,9 @@ const Browse = (props: AnalysisListProps) => {
     <div>
       <Row type="flex" justify="center">
         <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
+        <h3>
+          {'Public Analyses'}
+        </h3>
           <br />
           <AnalysisList {...listProps} />
         </Col>

--- a/neuroscout/frontend/src/Browse.tsx
+++ b/neuroscout/frontend/src/Browse.tsx
@@ -9,9 +9,6 @@ const Browse = (props: AnalysisListProps) => {
     <div>
       <Row type="flex" justify="center">
         <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
-          <h2>
-            {'Public Analyses'}
-          </h2>
           <br />
           <AnalysisList {...listProps} />
         </Col>

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -782,21 +782,19 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
           />
       <Row type="flex" justify="center"style={{ background: '#fff', padding: 0 }}>
         <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
-              <h2>
-                {!isDraft ? <Icon type="lock" /> : <Icon type="unlock" />}
-                {`Analysis ID: ${analysis.analysisId || 'n/a'}`}
-                <Space />
-                <Space />
-                <Space />
-                <Button
-                  onClick={this.saveAnalysis({ compile: false })}
-                  disabled={!this.saveEnabled()}
-                  type={'primary'}
-                >
-                  Save
-                </Button>
-                <Space />
-              </h2>
+        <h3>
+
+              <Button
+                onClick={this.saveAnalysis({ compile: false })}
+                disabled={!this.saveEnabled()}
+                type={'primary'}
+              >
+                Save
+              </Button>
+
+                {`ID: ${analysis.analysisId || 'n/a'}`}
+
+              </h3>
               <br />
             </Col>
           </Row>
@@ -807,6 +805,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
                 onTabClick={newTab => this.setState({ activeTab: newTab })}
                 onChange={this.tabChange}
                 className="builderTabs"
+                tabPosition="left"
               >
                 {isDraft && <TabPane tab="Overview" key="overview" disabled={!isDraft}>
                   <OverviewTab

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -5,7 +5,7 @@
 import { RouteComponentProps } from 'react-router';
 import { createBrowserHistory } from 'history';
 import * as React from 'react';
-import { Tabs, Row, Col, Layout, Button, Modal, Icon, message } from 'antd';
+import { Tag, Tabs, Row, Col, Layout, Button, Modal, Icon, message } from 'antd';
 import { Prompt } from 'react-router-dom';
 import { OverviewTab } from './Overview';
 import { PredictorSelector } from './Predictors';
@@ -718,21 +718,32 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     .catch(displayError);
   }
 
-  nextButton = (disabled = false) => {
+  nextbackButtons = (disabled = false) => {
     return (
-      <Button type="primary" onClick={this.nextTab()} className="nextButton" disabled={disabled}>
-        Next
-      </Button>
+      <Button.Group style={{'float': 'right'}}>
+        <Button type="primary" onClick={this.nextTab(-1)}>
+          Previous
+        </Button>
+        <Button type="primary" onClick={this.nextTab()} className="nextButton" disabled={disabled}>
+          Next
+        </Button>
+      </Button.Group>
     );
   }
 
   navButtons = (disabled = false) => {
     return (
       <div>
-        <Button type="primary" onClick={this.nextTab(-1)}>
-          Previous
+        <Button
+          onClick={this.saveAnalysis({ compile: false })}
+          disabled={!this.saveEnabled()}
+          type={'primary'}
+        >
+          Save
         </Button>
-        {this.nextButton(disabled)}
+        <Space/>
+        <Tag>{`ID: n/a`}</Tag>
+        {this.nextbackButtons(disabled)}
       </div>
     );
   }
@@ -780,24 +791,6 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
             when={unsavedChanges}
             message={'You have unsaved changes. Are you sure you want leave this page?'}
           />
-      <Row type="flex" justify="center"style={{ background: '#fff', padding: 0 }}>
-        <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
-        <h3>
-
-              <Button
-                onClick={this.saveAnalysis({ compile: false })}
-                disabled={!this.saveEnabled()}
-                type={'primary'}
-              >
-                Save
-              </Button>
-
-                {`ID: ${analysis.analysisId || 'n/a'}`}
-
-              </h3>
-              <br />
-            </Col>
-          </Row>
           <Row type="flex" justify="center" style={{ background: '#fff', padding: 0 }}>
             <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
               <Tabs
@@ -817,7 +810,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
                     updateAnalysis={this.updateState('analysis')}
                     updateSelectedTaskId={this.updateState('selectedTaskId')}
                   />
-                  {this.nextButton(!(!!this.state.analysis.name && this.state.analysis.runIds.length > 0))}
+                  {this.navButtons(!(!!this.state.analysis.name && this.state.analysis.runIds.length > 0))}
                   <br/>
                 </TabPane>}
                 {isDraft && <TabPane tab="Predictors" key="predictors" disabled={!predictorsActive || !isDraft}>
@@ -882,7 +875,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
                         availablePredictors={this.state.availablePredictors}
                       />
                       <br/>
-                      {isDraft ? this.navButtons() : this.nextButton()}
+                      {this.navButtons()}
                       <br/>
                     </div>
                   }

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -718,12 +718,14 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     .catch(displayError);
   }
 
-  nextbackButtons = (disabled = false) => {
+  nextbackButtons = (disabled = false, prev = true) => {
     return (
       <Button.Group style={{'float': 'right'}}>
-        <Button type="primary" onClick={this.nextTab(-1)}>
-          Previous
-        </Button>
+        {prev &&
+          <Button type="primary" onClick={this.nextTab(-1)}>
+            Previous
+          </Button>
+        }
         <Button type="primary" onClick={this.nextTab()} className="nextButton" disabled={disabled}>
           Next
         </Button>
@@ -731,7 +733,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     );
   }
 
-  navButtons = (disabled = false) => {
+  navButtons = (disabled = false, prev = true) => {
     return (
       <div>
         <Button
@@ -743,7 +745,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
         </Button>
         <Space/>
         <Tag>{`ID: n/a`}</Tag>
-        {this.nextbackButtons(disabled)}
+        {this.nextbackButtons(disabled, prev)}
       </div>
     );
   }
@@ -810,7 +812,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
                     updateAnalysis={this.updateState('analysis')}
                     updateSelectedTaskId={this.updateState('selectedTaskId')}
                   />
-                  {this.navButtons(!(!!this.state.analysis.name && this.state.analysis.runIds.length > 0))}
+                  {this.navButtons(!(!!this.state.analysis.name && this.state.analysis.runIds.length > 0), false)}
                   <br/>
                 </TabPane>}
                 {isDraft && <TabPane tab="Predictors" key="predictors" disabled={!predictorsActive || !isDraft}>

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -55,6 +55,12 @@ const editableStatus = ['DRAFT', 'FAILED'];
 
 const defaultConfig: AnalysisConfig = { smoothing: DEFAULT_SMOOTHING, predictorConfigs: {} };
 
+class AnalysisId extends React.Component<{id: undefined | string}, {}> {
+  render() {
+    return (<div>ID: {this.props.id ? this.props.id : 'n/a'}</div>);
+  }
+}
+
 // Create initialized app state (used in the constructor of the top-level App component)
 let initializeStore = (): Store => ({
   activeTab: 'overview',
@@ -734,6 +740,10 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
   }
 
   navButtons = (disabled = false, prev = true) => {
+    let analysisId: string | undefined = undefined;
+    if (this.state.analysis && this.state.analysis.analysisId) {
+      analysisId = this.state.analysis.analysisId;
+    }
     return (
       <div>
         <Button
@@ -744,7 +754,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
           Save
         </Button>
         <Space/>
-        <Tag>{`ID: n/a`}</Tag>
+        <Tag><AnalysisId id={analysisId}/></Tag>
         {this.nextbackButtons(disabled, prev)}
       </div>
     );

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -501,7 +501,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
       if (this.state.activeTab === 'overview') {
         // need name and runids
         if (this.state.analysis.name.length < 1) {
-          // how 
+          // how
         }
         if (this.state.analysis.runIds.length < 1) {
         }
@@ -787,6 +787,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
                 {`Analysis ID: ${analysis.analysisId || 'n/a'}`}
                 <Space />
                 <Space />
+                <Space />
                 <Button
                   onClick={this.saveAnalysis({ compile: false })}
                   disabled={!this.saveEnabled()}
@@ -799,7 +800,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
               <br />
             </Col>
           </Row>
-          <Row type="flex" justify="center"style={{ background: '#fff', padding: 0 }}>
+          <Row type="flex" justify="center" style={{ background: '#fff', padding: 0 }}>
             <Col xxl={{span: 14}} xl={{span: 16}} lg={{span: 18}} xs={{span: 24}} className="mainCol">
               <Tabs
                 activeKey={activeTab}

--- a/neuroscout/frontend/src/ContrastEditor.tsx
+++ b/neuroscout/frontend/src/ContrastEditor.tsx
@@ -152,7 +152,6 @@ export default class ContrastEditor extends React.Component<
                 value={weights[i]}
                 onChange={(this.updateWeight.bind(this, i))}
                 required={true}
-                min={1}
               />
             </FormItem>
           )}

--- a/neuroscout/frontend/src/Home.tsx
+++ b/neuroscout/frontend/src/Home.tsx
@@ -36,7 +36,7 @@ class Home extends React.Component<HomeProps, {}> {
                 analyses.length > 0 &&
                 <div>
                   <br />
-                  <h2>Your saved analyses:</h2>
+                  <h3>Your saved analyses</h3>
                   <br />
                   <AnalysisList {...listProps} />
                 </div>}

--- a/neuroscout/frontend/src/Home.tsx
+++ b/neuroscout/frontend/src/Home.tsx
@@ -28,19 +28,6 @@ class Home extends React.Component<HomeProps, {}> {
           <br />
         </Col>
       </Row>
-      <Row type="flex" justify="center"style={{ background: '#fff', padding: 0 }}>
-        <Col lg={{span: 6, offset: 2}}>
-          <Button type="primary" size="large" href="/builder" disabled={!loggedIn}>
-            Create New Analysis
-          </Button>
-        </Col>
-        <Col lg={0} md={1}/>
-        <Col lg={{span: 6, offset: 2}}>
-          <Button type="primary" size="large" href="/browse">
-            Browse Public Analyses
-          </Button>
-        </Col>
-      </Row>
       {loggedIn &&
         <div>
           <Row type="flex" justify="center"style={{ background: '#fff', padding: 0 }}>

--- a/neuroscout/frontend/src/Overview.tsx
+++ b/neuroscout/frontend/src/Overview.tsx
@@ -214,6 +214,13 @@ export class OverviewTab extends React.Component<OverviewTabProps, OverviewTabSt
       selectedRowKeys: analysis.runIds
     };
 
+    let runMsg;
+    if (analysis.runIds.length === this.props.availableRuns.length) {
+      runMsg = 'Runs: All selected';
+    } else {
+      runMsg = 'Runs: ${analysis.runIds.length}/${this.props.availableRuns.length} selected';
+    }
+
     return (
       <div className="builderCol">
         <Form layout="vertical">
@@ -281,7 +288,7 @@ export class OverviewTab extends React.Component<OverviewTabProps, OverviewTabSt
                     pagination={(datasets.length > 10) ? {'position': 'bottom'} : false}
                   />
               </Panel>
-              <Panel header="Select runs" key="runs">
+              <Panel header={runMsg} key="runs">
                 <Table
                   columns={this.state.runColumns}
                   rowKey="id"

--- a/neuroscout/frontend/src/Status.tsx
+++ b/neuroscout/frontend/src/Status.tsx
@@ -148,7 +148,9 @@ export class Results extends React.Component<submitProps, {compileTraceback: str
           <h3>Analysis Passed</h3>
           <p>
             Congratulations! Your analysis is finished compiling and is ready to be executed.
-            Once you have installed neuroscout-cli you may run your analysis like this:
+            Once you have installed neuroscout-cli you may run your analysis with the following command, 
+            replacing '/local/outputdirectory' with the directory on your local computer where results 
+            should be stored:
           </p>
           <pre>
             <code>

--- a/neuroscout/frontend/src/auth.actions.ts
+++ b/neuroscout/frontend/src/auth.actions.ts
@@ -5,7 +5,7 @@ var authActions = Reflux.createActions({
   'jwtFetch': {sync: false, asyncResult: true},
   'authenticate': {sync: false, asyncResult: true},
   'login': {},
-  'signUp': {},
+  'signup': {},
   'confirmLogout': {},
   'resetPassword': {},
   'submitToken': {},

--- a/neuroscout/frontend/src/auth.store.ts
+++ b/neuroscout/frontend/src/auth.store.ts
@@ -163,28 +163,28 @@ export class AuthStore extends Reflux.Store {
         'Content-type': 'application/json'
       }
     })
-      .then(response => response.json().then(json => ({ ...json, statusCode: response.status })))
-      .then((data: any) => {
-        if (data.statusCode !== 200) {
-          let errorMessage = '';
-          Object.keys(data.message).forEach(key => {
-            errorMessage += data.message[key];
-          });
-          this.update({
-            signupError: errorMessage
-          });
-          throw new Error('Signup failed!');
-        }
-        this.update({ name, email, openSignup: false, signupError: '' });
-        Modal.success({
-          title: 'Account created!',
-          content: 'Your account has been sucessfully created. \
-          You will receive a confirmation email shortly. Please follow the instructions to activate your account\
-          and start using Neuroscout. ',
-          okText: 'Okay',
+    .then(response => response.json().then(json => ({ ...json, statusCode: response.status })))
+    .then((data: any) => {
+      if (data.statusCode !== 200) {
+        let errorMessage = '';
+        Object.keys(data.message).forEach(key => {
+          errorMessage += data.message[key];
         });
-      })
-      .catch(displayError);
+        this.update({
+          signupError: errorMessage
+        });
+        throw new Error('Signup failed!');
+      }
+      this.update({ name, email, openSignup: false, signupError: '' });
+      Modal.success({
+        title: 'Account created!',
+        content: 'Your account has been sucessfully created. \
+        You will receive a confirmation email shortly. Please follow the instructions to activate your account\
+        and start using Neuroscout. ',
+        okText: 'Okay',
+      });
+    })
+    .catch(displayError);
   }
 
   // Log user out

--- a/neuroscout/frontend/src/auth.store.ts
+++ b/neuroscout/frontend/src/auth.store.ts
@@ -154,8 +154,8 @@ export class AuthStore extends Reflux.Store {
   };
 
   // Sign up for a new account
-  signup = () => {
-    const { name, email, password, openSignup } = this.state;
+  signup() {
+    const { name, email, password, openSignup } = this.state.auth;
     fetch(DOMAINROOT + '/api/user', {
       method: 'post',
       body: JSON.stringify({ email: email, password: password, name: name }),
@@ -185,7 +185,7 @@ export class AuthStore extends Reflux.Store {
         });
       })
       .catch(displayError);
-  };
+  }
 
   // Log user out
   logout = () => {


### PR DESCRIPTION
This PR is a relatively big aesthetic change to the UI.
The main change is the use of a Menu bar at the top, and flipping the Builder tabs to be vertical.

The main things left to do for now:

- [x] Add ability to disable "Previous" button for first Builder tab
- [x] Plug in "ID" tag at the bottom of the buider
- [x] if you go the URL without clicking through the menu, the appropriate menu icon should be highlighted (not as important, but a bit confusing because otherwise it stays highlighted)

Later on we can fill the "My Profile" and "Help" tabs with content.

@rwblair can you take care of those things, and take a good look and give me some feedback? I'm not 100% sure the routing is correctly implemented 