### PR TITLE
Allow skipping Analysis build

### DIFF
--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -382,7 +382,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
   };
 
   // Save analysis to server, either with lock=false (just save), or lock=true (save & submit)
-  saveAnalysis = ({ compile = false }) => (): void => {
+  saveAnalysis = ({ compile = false, build = true}) => (): void => {
     /*
     if ((!compile && !this.saveEnabled()) || (compile && !this.submitEnabled())) {
       return;
@@ -421,7 +421,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     let url: string;
     if (compile && analysis.analysisId) {
       // Submit for compilation
-      url = `${domainRoot}/api/analyses/${analysis.analysisId}/compile`;
+      url = `${domainRoot}/api/analyses/${analysis.analysisId}/compile?build=${build}`;
       method = 'post';
       this.setState({analysis: {...analysis, status: 'SUBMITTING'}});
       this.checkAnalysisStatus();
@@ -540,7 +540,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     return Promise.resolve(analysis);
   };
 
-  confirmSubmission = (): void => {
+  confirmSubmission = (build: boolean): void => {
     if (!this.submitEnabled()) return;
     const { saveAnalysis } = this;
     Modal.confirm({
@@ -551,22 +551,9 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
       cancelText: 'No',
       onOk() {
         // saveAnalysis({ compile: false})();
-        saveAnalysis({ compile: true })();
+        saveAnalysis({ compile: true, build: build })();
       }
     });
-  };
-
-  generateButton = () => {
-      return (
-        <Button
-          hidden={!this.state.analysis.analysisId}
-          onClick={this.confirmSubmission}
-          type={'primary'}
-          disabled={!this.submitEnabled()}
-        >
-          {this.state.unsavedChanges ? 'Save & Generate' : 'Generate'}
-        </Button>
-      );
   };
 
   nextTab = (direction = 1) => {
@@ -979,7 +966,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
                     updateAnalysis={this.updateAnalysis}
                     userOwns={this.props.userOwns}
                   >
-                  {this.props.userOwns &&
+                  {this.props.userOwns && !isDraft &&
                       <EditDetails
                         name={analysis.name}
                         description={analysis.description}

--- a/neuroscout/frontend/src/Status.tsx
+++ b/neuroscout/frontend/src/Status.tsx
@@ -97,9 +97,8 @@ export class Submit extends React.Component<submitProps, {tosAgree: boolean, val
     if (!e.target.checked) {
       Modal.confirm({
         title: 'Disable validation of model?',
-        content: `Disabling validation of the model will speed up analysis bundle generation but may cause the 
-          analysis to crash during execution if any selected predictors do not exist for all selected 
-          runs/sessions/subjects.`,
+        content: `Disabling validation of the model will speed up bundle generation
+          but can lead to unexpected errors at runtime. Use at your own risk!`,
         onOk() {
           setState({validate: e.target.checked});
         }

--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -7,131 +7,137 @@ from worker import celery_app
 import webargs as wa
 from marshmallow import fields
 from ..utils import owner_required, abort, fetch_analysis
-from .schemas import (AnalysisFullSchema, AnalysisResourcesSchema, ReportSchema,
-                      AnalysisCompiledSchema)
+from .schemas import (AnalysisFullSchema, AnalysisResourcesSchema,
+                      ReportSchema, AnalysisCompiledSchema)
 import celery.states as states
 from utils import put_record
 import datetime
 
+
 def dump_pe(pes):
-	""" Serialize PredictorEvents, with *SPEED*, using core SQL.
-	Warning: relies on attributes being in correct order. """
-	statement = str(pes.statement.compile(dialect=postgresql.dialect()))
-	params = pes.statement.compile(dialect=postgresql.dialect()).params
-	res = db.session.connection().execute(statement, params)
-	return [{
-	  'onset': r[1],
-	  'duration': r[2],
-	  'value':  r[3],
-	  'run_id': r[5],
-	  'predictor_id': r[6]
-	  } for r in res]
+    """ Serialize PredictorEvents, with *SPEED*, using core SQL.
+    Warning: relies on attributes being in correct order. """
+    statement = str(pes.statement.compile(dialect=postgresql.dialect()))
+    params = pes.statement.compile(dialect=postgresql.dialect()).params
+    res = db.session.connection().execute(statement, params)
+    return [{
+      'onset': r[1],
+      'duration': r[2],
+      'value':  r[3],
+      'run_id': r[5],
+      'predictor_id': r[6]
+      } for r in res]
+
 
 def jsonify_analysis(analysis, run_id=None):
-	"""" Serialize to JSON analysis's predictor events
-	Queries PredictorEvents to get all events for all runs and predictors. """
+    """" Serialize to JSON analysis's predictor events
+    Queries PredictorEvents to get all events for all runs and predictors. """
 
+    analysis_json = AnalysisFullSchema().dump(analysis)[0]
+    pred_ids = [p['id'] for p in analysis_json['predictors']]
+    all_runs = [r['id'] for r in analysis_json['runs']]
 
+    if run_id is None:
+        run_id = all_runs
+    if not set(run_id) <= set(all_runs):
+        raise ValueError("Incorrect run id specified")
 
-	analysis_json = AnalysisFullSchema().dump(analysis)[0]
-	pred_ids = [p['id'] for p in analysis_json['predictors']]
-	all_runs = [r['id'] for r in analysis_json['runs']]
+    pes = PredictorEvent.query.filter(
+        (PredictorEvent.predictor_id.in_(pred_ids)) &
+        (PredictorEvent.run_id.in_(run_id)))
 
-	if run_id is None:
-		run_id = all_runs
-	if not set(run_id) <= set(all_runs):
-		raise ValueError("Incorrect run id specified")
+    return analysis_json, dump_pe(pes)
 
-	pes = PredictorEvent.query.filter(
-	    (PredictorEvent.predictor_id.in_(pred_ids)) & \
-	    (PredictorEvent.run_id.in_(run_id)))
-
-	return analysis_json, dump_pe(pes)
 
 @doc(tags=['analysis'])
 @marshal_with(AnalysisCompiledSchema)
 class CompileAnalysisResource(MethodResource):
-	@doc(summary='Compile and lock analysis.')
-	@owner_required
-	def post(self, analysis):
-		put_record(
-			{'status': 'SUBMITTING', 'submitted_at': datetime.datetime.utcnow()},
-			analysis)
+    @doc(summary='Compile and lock analysis.')
+    @owner_required
+    def post(self, analysis):
+        put_record(
+            {'status': 'SUBMITTING',
+             'submitted_at': datetime.datetime.utcnow()},
+            analysis)
 
-		try:
-			task = celery_app.send_task(
-					'workflow.compile',
-					args=[*jsonify_analysis(analysis),
-					AnalysisResourcesSchema().dump(analysis)[0],
-					analysis.dataset.local_path, None]
-					)
-		except:
-			put_record(
-				{'status': 'FAILED', 'compile_traceback': "Submitting failed. Perhaps analysis is too large?"},
-				analysis)
+        try:
+            task = celery_app.send_task(
+                'workflow.compile',
+                args=[*jsonify_analysis(analysis),
+                      AnalysisResourcesSchema().dump(analysis)[0],
+                      analysis.dataset.local_path, None]
+                )
+        except:
+            put_record(
+                {'status': 'FAILED',
+                 'compile_traceback': "Submitting failed. "
+                 "Perhaps analysis is too large?"},
+                analysis)
 
-		put_record({'status': 'PENDING', 'compile_task_id': task.id}, analysis)
+        put_record({'status': 'PENDING', 'compile_task_id': task.id}, analysis)
 
-		return analysis
+        return analysis
 
-	@doc(summary='Check if analysis compilation status.')
-	@fetch_analysis
-	def get(self, analysis):
-		return analysis
+    @doc(summary='Check if analysis compilation status.')
+    @fetch_analysis
+    def get(self, analysis):
+        return analysis
+
 
 @marshal_with(ReportSchema)
 @use_kwargs({
-	'run_id': wa.fields.DelimitedList(fields.Int(),
-                                    description='Run id(s).')
+    'run_id': wa.fields.DelimitedList(fields.Int(),
+                                      description='Run id(s).')
 }, locations=['query'])
 @doc(tags=['analysis'])
 class ReportResource(MethodResource):
-	@doc(summary='Generate analysis reports.')
-	@owner_required
-	def post(self, analysis, run_id=None):
-		# Submit report generation
-		analysis_json, pes_json = jsonify_analysis(analysis, run_id=run_id)
+    @doc(summary='Generate analysis reports.')
+    @owner_required
+    def post(self, analysis, run_id=None):
+        # Submit report generation
+        analysis_json, pes_json = jsonify_analysis(analysis, run_id=run_id)
 
-		task = celery_app.send_task('workflow.generate_report',
-				args=[analysis_json, pes_json,
-				analysis.dataset.local_path, run_id,
-				current_app.config['SERVER_NAME']])
+        task = celery_app.send_task(
+            'workflow.generate_report',
+            args=[analysis_json, pes_json,
+                  analysis.dataset.local_path, run_id,
+                  current_app.config['SERVER_NAME']])
 
-		# Create new Report
-		report = Report(
-			analysis_id=analysis.hash_id,
-			runs=run_id,
-			task_id=task.id
-		)
-		db.session.add(report)
-		db.session.commit()
+        # Create new Report
+        report = Report(
+            analysis_id=analysis.hash_id,
+            runs=run_id,
+            task_id=task.id
+            )
+        db.session.add(report)
+        db.session.commit()
 
-		return report
+        return report
 
-	@doc(summary='Get analysis reports.')
-	@fetch_analysis
-	def get(self, analysis, run_id=None):
-		filters = {'analysis_id': analysis.hash_id}
-		if run_id is not None:
-			filters['runs'] = run_id
+    @doc(summary='Get analysis reports.')
+    @fetch_analysis
+    def get(self, analysis, run_id=None):
+        filters = {'analysis_id': analysis.hash_id}
+        if run_id is not None:
+            filters['runs'] = run_id
 
-		candidate = Report.query.filter_by(**filters)
-		if candidate.count() == 0:
-			abort(404, "Report not found")
+        candidate = Report.query.filter_by(**filters)
+        if candidate.count() == 0:
+            abort(404, "Report not found")
 
-		report = candidate.filter_by(
-			generated_at=max(candidate.with_entities('generated_at'))).one()
+        report = candidate.filter_by(
+            generated_at=max(candidate.with_entities('generated_at'))).one()
 
-		if report.generated_at < analysis.modified_at:
-			abort(404, "No fresh reports available")
+        if report.generated_at < analysis.modified_at:
+            abort(404, "No fresh reports available")
 
-		if report.status == 'PENDING':
-			res = celery_app.AsyncResult(report.task_id)
-			if res.state == states.FAILURE:
-				put_record(
-					{'status': 'FAILED', 'traceback': res.traceback}, report)
-			elif res.state == states.SUCCESS:
-				put_record(
-					{'status': 'OK', 'result': res.result}, report)
+        if report.status == 'PENDING':
+            res = celery_app.AsyncResult(report.task_id)
+        if res.state == states.FAILURE:
+            put_record(
+                {'status': 'FAILED', 'traceback': res.traceback}, report)
+        elif res.state == states.SUCCESS:
+            put_record(
+                {'status': 'OK', 'result': res.result}, report)
 
-		return report
+        return report

--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -51,10 +51,14 @@ def jsonify_analysis(analysis, run_id=None):
 
 @doc(tags=['analysis'])
 @marshal_with(AnalysisCompiledSchema)
+@use_kwargs({
+    'build': wa.fields.Boolean(
+        description='Run id(s).')
+    }, locations=['query'])
 class CompileAnalysisResource(MethodResource):
     @doc(summary='Compile and lock analysis.')
     @owner_required
-    def post(self, analysis):
+    def post(self, analysis, build=False):
         put_record(
             {'status': 'SUBMITTING',
              'submitted_at': datetime.datetime.utcnow()},
@@ -65,7 +69,7 @@ class CompileAnalysisResource(MethodResource):
                 'workflow.compile',
                 args=[*jsonify_analysis(analysis),
                       AnalysisResourcesSchema().dump(analysis)[0],
-                      analysis.dataset.local_path, None]
+                      analysis.dataset.local_path, None, build]
                 )
         except:
             put_record(

--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -53,7 +53,7 @@ def jsonify_analysis(analysis, run_id=None):
 @marshal_with(AnalysisCompiledSchema)
 @use_kwargs({
     'build': wa.fields.Boolean(
-        description='Run id(s).')
+        description='Build Analysis object')
     }, locations=['query'])
 class CompileAnalysisResource(MethodResource):
     @doc(summary='Compile and lock analysis.')


### PR DESCRIPTION
This PR allows users to skip building the analysis object (aka validating through pybids) when compiling the bundle.

@rwblair can you add an option to skip building in the analysis builder?

I'm imagining it would either be a checkbox (that when you uncheck it it warns you with a modal to confirm), or a setting under a hidden 'advanced' settings toggle. 