### PR TITLE
HOTFIX: Only need build argument on post not get

### DIFF
--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -51,13 +51,13 @@ def jsonify_analysis(analysis, run_id=None):
 
 @doc(tags=['analysis'])
 @marshal_with(AnalysisCompiledSchema)
-@use_kwargs({
-    'build': wa.fields.Boolean(
-        description='Build Analysis object')
-    }, locations=['query'])
 class CompileAnalysisResource(MethodResource):
     @doc(summary='Compile and lock analysis.')
     @owner_required
+    @use_kwargs({
+        'build': wa.fields.Boolean(
+            description='Build Analysis object')
+        }, locations=['query'])
     def post(self, analysis, build=False):
         put_record(
             {'status': 'SUBMITTING',


### PR DESCRIPTION
The build parameter was being passed to the `get` route, even though it didn't need it (and would cause it to crash)