### PR TITLE
Add auto-fill functionality

### DIFF
--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -68,6 +68,7 @@ route_factory(app, docs,
         ('ReportResource', 'analyses/<analysis_id>/report'),
         ('AnalysisResourcesResource', 'analyses/<analysis_id>/resources'),
         ('AnalysisBundleResource', 'analyses/<analysis_id>/bundle'),
+        ('AnalysisFillResource', 'analyses/<analysis_id>/fill')
         ('RunListResource', 'runs'),
         ('RunResource', 'runs/<int:run_id>'),
         ('PredictorListResource', 'predictors'),

--- a/neuroscout/resources/__init__.py
+++ b/neuroscout/resources/__init__.py
@@ -3,7 +3,8 @@
 from .analysis import (AnalysisResource, AnalysisRootResource,
                        CloneAnalysisResource, CompileAnalysisResource,
                        AnalysisBundleResource, AnalysisFullResource,
-                       AnalysisResourcesResource, ReportResource)
+                       AnalysisResourcesResource, ReportResource,
+                       AnalysisFillResource)
 from .dataset import DatasetSchema, DatasetResource, DatasetListResource
 from .predictor import (PredictorEventSchema, PredictorSchema,
                         PredictorListResource, PredictorResource,
@@ -20,6 +21,7 @@ __all__ = [
     'CompileAnalysisResource',
     'AnalysisBundleResource',
     'AnalysisFullResource',
+    'AnalysisFillResource',
     'AnalysisResourcesResource',
     'ReportResource',
     'DatasetSchema',

--- a/neuroscout/resources/analysis/__init__.py
+++ b/neuroscout/resources/analysis/__init__.py
@@ -1,14 +1,16 @@
 ''' Analysis resources. '''
 
 from .endpoints import (AnalysisResource, AnalysisRootResource,
-                       AnalysisBundleResource, CloneAnalysisResource,
-                       AnalysisFullResource, AnalysisResourcesResource)
+                        AnalysisBundleResource, CloneAnalysisResource,
+                        AnalysisFullResource, AnalysisResourcesResource,
+                        AnalysisFillResource)
 from .reports import CompileAnalysisResource, ReportResource
 
 __all__ = [
     'AnalysisResource',
     'AnalysisRootResource',
     'AnalysisFullResource',
+    'AnalysisFillResource',
     'AnalysisResourcesResource',
     'AnalysisBundleResource',
     'CloneAnalysisResource',

--- a/neuroscout/resources/analysis/endpoints.py
+++ b/neuroscout/resources/analysis/endpoints.py
@@ -88,7 +88,8 @@ class AnalysisFillResource(AnalysisMethodResource):
         if not analysis.runs:
             #  Set to all runs in dataset
             fields['runs'] = analysis.dataset.runs.all()
-
+            fields['model'] = analysis.model
+            fields['model'].pop("Input")
         if not analysis.predictors:
             # Look in model to see if there are predictor names
             try:
@@ -104,7 +105,8 @@ class AnalysisFillResource(AnalysisMethodResource):
                     fields['predictors'] = predictors
                 elif len(predictors) < len(names) and partial is True:
                     new_names = [p.name for p in predictors]
-                    fields['model'] = analysis.model
+                    if 'model' not in fields:
+                        fields['model'] = analysis.model
                     fields['model']['Steps'][0]['Model']['X'] = new_names
                     fields['predictors'] = predictors
 

--- a/neuroscout/resources/analysis/endpoints.py
+++ b/neuroscout/resources/analysis/endpoints.py
@@ -98,8 +98,12 @@ class AnalysisFillResource(AnalysisMethodResource):
                 names = None
 
             if names is not None:
+                runs = fields['runs'] if 'runs' in fields else analysis.runs
+                if 'runs' in fields:
+                    runs = fields['runs']
+                    
                 predictors = get_predictors(
-                    name=names, run_id=[r.id for r in analysis.runs])
+                    name=names, run_id=[r.id for r in runs])
 
                 if len(predictors) == len(names):
                     fields['predictors'] = predictors

--- a/neuroscout/resources/analysis/schemas.py
+++ b/neuroscout/resources/analysis/schemas.py
@@ -1,118 +1,128 @@
-from marshmallow import Schema, fields, validates, ValidationError, post_load, pre_load
-from models import  Dataset, Run, Predictor
+from marshmallow import (Schema, fields, validates, ValidationError,
+                         post_load, pre_load)
+from models import Dataset, Run, Predictor
+
 
 class AnalysisSchema(Schema):
-	""" Primary analysis schema """
-	hash_id = fields.Str(dump_only=True, description='Hashed analysis id.')
-	parent_id = fields.Str(dump_only=True, description="Parent analysis, if cloned.")
+    """ Primary analysis schema """
+    hash_id = fields.Str(dump_only=True, description='Hashed analysis id.')
+    parent_id = fields.Str(dump_only=True,
+                           description="Parent analysis, if cloned.")
 
-	name = fields.Str(required=True, description='Analysis name.')
-	description = fields.Str()
-	predictions = fields.Str(description='User apriori predictions.')
+    name = fields.Str(required=True, description='Analysis name.')
+    description = fields.Str()
+    predictions = fields.Str(description='User apriori predictions.')
 
-	dataset_id = fields.Int(required=True)
-	task_name = fields.Str(description='Task name', dump_only=True)
-	TR = fields.Float(description='Time repetition (s)', dump_only=True)
+    dataset_id = fields.Int(required=True)
+    task_name = fields.Str(description='Task name', dump_only=True)
+    TR = fields.Float(description='Time repetition (s)', dump_only=True)
 
-	model = fields.Dict(description='BIDS model.')
+    model = fields.Dict(description='BIDS model.')
 
-	created_at = fields.Time(dump_only=True)
-	modified_at = fields.Time(dump_only=True)
-	submitted_at = fields.Time(
-		description='Timestamp of when analysis was submitted for compilation',
-		dump_only=True)
-	status = fields.Str(
-		description='PASSED, FAILED, PENDING, or DRAFT.', dump_only=True)
-	locked = fields.Bool(
-		description='Is analysis locked by admins?', dump_only=True)
-	compile_traceback = fields.Str(
-		description='Traceback of compilation error.', dump_only=True)
+    created_at = fields.Time(dump_only=True)
+    modified_at = fields.Time(dump_only=True)
+    submitted_at = fields.Time(
+        description='Timestamp of when analysis was submitted for compilation',
+        dump_only=True)
+    status = fields.Str(
+        description='PASSED, FAILED, PENDING, or DRAFT.', dump_only=True)
+    locked = fields.Bool(
+        description='Is analysis locked by admins?', dump_only=True)
+    compile_traceback = fields.Str(
+        description='Traceback of compilation error.', dump_only=True)
 
-	private = fields.Bool(description='Analysis private or discoverable?')
+    private = fields.Bool(description='Analysis private or discoverable?')
 
-	predictors = fields.Nested(
-		'PredictorSchema', many=True, only='id',
+    predictors = fields.Nested(
+        'PredictorSchema', many=True, only='id',
         description='Predictor id(s) associated with analysis')
 
-	runs = fields.Nested(
-		'RunSchema', many=True, only='id',
+    runs = fields.Nested(
+        'RunSchema', many=True, only='id',
         description='Runs associated with analysis')
 
-	@validates('dataset_id')
-	def validate_dsid(self, value):
-		if Dataset.query.filter_by(id=value).count() == 0:
-			raise ValidationError('Invalid dataset id.')
+    @validates('dataset_id')
+    def validate_dsid(self, value):
+        if Dataset.query.filter_by(id=value).count() == 0:
+            raise ValidationError('Invalid dataset id.')
 
-	@validates('runs')
-	def validate_runs(self, value):
-		try:
-			[Run.query.filter_by(**r).one() for r in value]
-		except:
-			raise ValidationError('Invalid run id!')
+    @validates('runs')
+    def validate_runs(self, value):
+        try:
+            [Run.query.filter_by(**r).one() for r in value]
+        except:
+            raise ValidationError('Invalid run id!')
 
-	@validates('predictors')
-	def validate_preds(self, value):
-		try:
-			[Predictor.query.filter_by(**r).one() for r in value]
-		except:
-			raise ValidationError('Invalid predictor id.')
+    @validates('predictors')
+    def validate_preds(self, value):
+        try:
+            [Predictor.query.filter_by(**r).one() for r in value]
+        except:
+            raise ValidationError('Invalid predictor id.')
 
-	@pre_load
-	def unflatten(self, in_data):
-		if 'runs' in in_data:
-		    in_data['runs'] = [{"id": r} for r in in_data['runs']]
-		if 'predictors' in in_data:
-			in_data['predictors'] = [{"id": r} for r in in_data['predictors']]
+    @pre_load
+    def unflatten(self, in_data):
+        if 'runs' in in_data:
+            in_data['runs'] = [{"id": r} for r in in_data['runs']]
+        if 'predictors' in in_data:
+            in_data['predictors'] = [{"id": r} for r in in_data['predictors']]
 
-		return in_data
+        return in_data
 
-	@post_load
-	def nested_object(self, args):
-		if 'runs' in args:
-			args['runs'] = [Run.query.filter_by(**r).one() for r in args['runs']]
+    @post_load
+    def nested_object(self, args):
+        if 'runs' in args:
+            args['runs'] = [
+                Run.query.filter_by(**r).one() for r in args['runs']]
 
-		if 'predictors' in args:
-			args['predictors'] = [Predictor.query.filter_by(**r).one() for r in args['predictors']]
+        if 'predictors' in args:
+            args['predictors'] = [
+                Predictor.query.filter_by(**r).one()
+                for r in args['predictors']]
 
-		return args
+        return args
 
-	class Meta:
-		strict = True
+    class Meta:
+        strict = True
+
 
 class AnalysisFullSchema(AnalysisSchema):
-	""" Analysis schema, with additional nested fields """
-	runs = fields.Nested(
-		'RunSchema', many=True, description='Runs associated with analysis',
-	    exclude=['dataset_id', 'task'], dump_only=True)
+    """ Analysis schema, with additional nested fields """
+    runs = fields.Nested(
+        'RunSchema', many=True, description='Runs associated with analysis',
+        exclude=['dataset_id', 'task'], dump_only=True)
 
-	predictors = fields.Nested(
-		'PredictorSchema', many=True, only=['id', 'name'],
+    predictors = fields.Nested(
+        'PredictorSchema', many=True, only=['id', 'name'],
         description='Predictor id(s) associated with analysis', dump_only=True)
 
+
 class AnalysisResourcesSchema(Schema):
-	""" Schema for Analysis resources. """
-	preproc_address = fields.Nested(
-		'DatasetSchema', only='preproc_address', attribute='dataset')
-	dataset_address = fields.Nested(
-		'DatasetSchema', only='dataset_address', attribute='dataset')
-	dataset_name = fields.Nested(
-		'DatasetSchema', only='name', attribute='dataset')
-	func_paths = fields.Nested(
-		'RunSchema', many=True, only='func_path', attribute='runs')
-	mask_paths = fields.Nested(
-		'RunSchema', many=True, only='mask_path', attribute='runs')
+    """ Schema for Analysis resources. """
+    preproc_address = fields.Nested(
+        'DatasetSchema', only='preproc_address', attribute='dataset')
+    dataset_address = fields.Nested(
+        'DatasetSchema', only='dataset_address', attribute='dataset')
+    dataset_name = fields.Nested(
+        'DatasetSchema', only='name', attribute='dataset')
+    func_paths = fields.Nested(
+        'RunSchema', many=True, only='func_path', attribute='runs')
+    mask_paths = fields.Nested(
+        'RunSchema', many=True, only='mask_path', attribute='runs')
+
 
 class AnalysisCompiledSchema(Schema):
-	""" Simple route for checking if analysis compilation status. """
-	status = fields.Str(description='PASSED, FAILED, PENDING, or DRAFT.',
-		dump_only=True)
-	compile_traceback = fields.Str(
-		description='Traceback of compilation error.')
+    """ Simple route for checking if analysis compilation status. """
+    status = fields.Str(description='PASSED, FAILED, PENDING, or DRAFT.',
+                        dump_only=True)
+    compile_traceback = fields.Str(
+        description='Traceback of compilation error.')
+
 
 class ReportSchema(Schema):
-	""" Schema for report results """
-	generated_at = fields.Time(description='Time report was generated')
-	result = fields.Dict(description='Links to report resources')
-	status = fields.Str(description='Report status')
-	traceback = fields.Str(
-		description='Traceback of generation error.')
+    """ Schema for report results """
+    generated_at = fields.Time(description='Time report was generated')
+    result = fields.Dict(description='Links to report resources')
+    status = fields.Str(description='Report status')
+    traceback = fields.Str(
+        description='Traceback of generation error.')


### PR DESCRIPTION
WIP.

Adds a route at `/api/analyses/{ID}/fill`.
This is a `POST` route. It will try to fill sensible defaults for the following fields:
- `runs`: Defaults to all runs
- `predictors`: Will look in model and try to find names from `X`. Then will query for all the latest predictors for the specified runs matching those names.

Note that this is not a `PUT` route, so changes to the model (e.g. blanking `predictors`) will have to be done using the appropriate route.

Closes #462 