### PR TITLE
Fix report generation issues

### DIFF
--- a/celery_worker/tasks.py
+++ b/celery_worker/tasks.py
@@ -165,7 +165,9 @@ def _plot_save(dm, plotter, outfile, **kwargs):
 class PathBuilder():
     def __init__(self, outdir, domain, hash, entities):
         self.outdir = outdir
-        self.domain = domain
+        prepend = "https://" if "neuroscout.org" in domain else "http://"
+        logger.error(prepend)
+        self.domain = prepend + domain
         self.hash = hash
         self.entities = entities
 

--- a/neuroscout/frontend/src/App.css
+++ b/neuroscout/frontend/src/App.css
@@ -1,29 +1,21 @@
 @import '~antd/dist/antd.css';
 
-/*.App {
-  text-align: center;
-}
-
-.App-logo {
-  animation: App-logo-spin infinite 20s linear;
-  height: 80px;
-}
-
-.App-header {
-  background-color: #222;
-  height: 150px;
-  padding: 20px;
-  color: white;
-}
-
-.App-intro {
-  font-size: large;
-}*/
-
 @keyframes App-logo-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+body {
+    background-color: white;
+}
+
+pre {
+    padding: 10px;
+    border-radius: 10px;
+    color: white;
+    background-color: black;
+}
+
 
 .Login-col {
   float: right;
@@ -37,8 +29,10 @@
   float: right;
 }
 
-body {
-    background-color: white;
+.privateSwitch {
+    text-align: center;
+    padding-right: 10px;
+    display: inline-block;
 }
 
 .builderTabs {
@@ -51,19 +45,6 @@ body {
 
 .mainCol {
     padding: 0 0px 0 0px;
-}
-
-pre {
-    padding: 10px;
-    border-radius: 10px;
-    color: white;
-    background-color: black;
-}
-
-.privateSwitch {
-    text-align: center;
-    padding-right: 10px;
-    display: inline-block;
 }
 
 .headerRow {
@@ -121,4 +102,9 @@ pre {
 
 .contrast-type-form-item {
     margin-bottom: 0px;
+}
+
+.designMatrix {
+    max-width: 100%;
+    max-height: 80vh;
 }

--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -359,6 +359,7 @@ class App extends Reflux.Component<any, {}, AppState> {
         footer={null}
         maskClosable={true}
         onCancel={e => {
+          authActions.logout();
           authActions.update({ openLogin: false });
         }}
       >

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -588,7 +588,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
         }
         if (this.state.analysis.runIds.length < 1) {
         }
-      } else if (!this.preTabChange()) {
+      } else if (!this.preTabChange(nextTab as TabName)) {
         return;
       }
       this.setState(update);
@@ -600,7 +600,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
    * current contents
    */
   onTabClick = (newTab: TabName) => {
-    if (!this.preTabChange()) {
+    if (!this.preTabChange(newTab)) {
       return;
     }
     this.setState({ activeTab: newTab });
@@ -608,7 +608,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
 
   // run any time we attempt to leave tab
   // xform and contrast checks are more or less the same save validate funciton call...
-  preTabChange = () => {
+  preTabChange = (nextTab: TabName) => {
     let errors: string[] = [];
     if (this.state.activeTab === 'transformations') {
       if (this.state.activeXform === undefined) {
@@ -629,6 +629,9 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     } else if (this.state.activeTab === 'contrasts') {
       if (this.state.activeContrast === undefined) {
         if (this.state.analysis.contrasts.length > 0) {
+          return true;
+        }
+        if (tabOrder.indexOf(nextTab) <= tabOrder.indexOf('contrasts')) {
           return true;
         }
         this.setState({contrastErrors: ['Minimum of one contrast required.']});

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -628,8 +628,12 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
       this.updateTransformations(newXforms);
     } else if (this.state.activeTab === 'contrasts') {
       if (this.state.activeContrast === undefined) {
-        return true;
-      }
+        if (this.state.analysis.contrasts.length > 0) {
+          return true;
+        }
+        this.setState({contrastErrors: ['Minimum of one contrast required.']});
+        return false;
+      } 
       errors = validateContrast(this.state.activeContrast);
       if (errors.length > 0) {
         this.setState({contrastErrors: errors});
@@ -640,10 +644,6 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
         newContrasts.push({...this.state.activeContrast});
       } else {
         newContrasts[this.state.activeContrastIndex] = {...this.state.activeContrast};
-      }
-      if (newContrasts.length < 1) {
-        this.setState({contrastErrors: ['Minimum of one contrast required.']});
-        return false;
       }
       this.updateContrasts(newContrasts);
     }

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -641,6 +641,10 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
       } else {
         newContrasts[this.state.activeContrastIndex] = {...this.state.activeContrast};
       }
+      if (newContrasts.length < 1) {
+        this.setState({contrastErrors: ['Minimum of one contrast required.']});
+        return false;
+      }
       this.updateContrasts(newContrasts);
     }
     return true;
@@ -934,7 +938,7 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     }[analysis.status];
     // Jump to submit/status tab if no longer a draft.
     if (analysis.status !== 'DRAFT' && activeTab === 'overview') {
-      activeTab = 'submit';
+      activeTab = 'review';
     }
     let isDraft = analysis.status === 'DRAFT';
     return (

--- a/neuroscout/frontend/src/Contrasts.tsx
+++ b/neuroscout/frontend/src/Contrasts.tsx
@@ -5,7 +5,7 @@
  - ContrastDisplay: component to display a single contrast
 */
 import * as React from 'react';
-import { Table, Input, Button, Row, Col, Form, Select, Checkbox, Icon, List } from 'antd';
+import { Alert, Table, Input, Button, Row, Col, Form, Select, Checkbox, Icon, List } from 'antd';
 import {
   DragDropContext,
   Draggable,
@@ -195,6 +195,25 @@ export class ContrastsTab extends React.Component<ContrastsTabProps, ContrastsTa
           {'Contrasts'}
         </h2>
         <br />
+        {this.props.contrastErrors.length > 0 && mode !== 'add' &&
+          <div>
+            <Alert
+              type="error"
+              showIcon={true}
+              closable={true}
+              message={
+                <ul>
+                  {this.props.contrastErrors.map((x, i) =>
+                    <li key={i}>
+                      {x}
+                    </li>
+                  )}
+                </ul>
+              }
+            />
+            <br />
+          </div>}
+
         <DragDropContext onDragEnd={this.onDragEnd}>
           <Droppable droppableId="droppable">
             {(provided: DroppableProvided, snapshot: DroppableStateSnapshot) => (

--- a/neuroscout/frontend/src/Report.tsx
+++ b/neuroscout/frontend/src/Report.tsx
@@ -41,7 +41,7 @@ class Plots extends React.Component<{plots: string[]}, {}> {
     render() {
       let display: any[] = [];
       let plots = this.props.plots.map((x, i) => {
-        let url = 'https://' + x;
+        let url = x;
         let sub = getSub(x, 'sub');
         let run = getSub(x, 'run');
         // urls generated for localhost have None instead of localhost in url

--- a/neuroscout/frontend/src/Report.tsx
+++ b/neuroscout/frontend/src/Report.tsx
@@ -40,7 +40,11 @@ let getSub = (x: string, pre: string) => {
 class Plots extends React.Component<{plots: string[]}, {}> {
     render() {
       let display: any[] = [];
+      let firstUrl = '';
       let plots = this.props.plots.map((x, i) => {
+        if (i === 0) {
+          firstUrl = x;
+        }
         let url = x;
         let sub = getSub(x, 'sub');
         let run = getSub(x, 'run');
@@ -56,7 +60,7 @@ class Plots extends React.Component<{plots: string[]}, {}> {
         );
       });
       return(
-        <Collapse defaultActiveKey={['0']}>
+        <Collapse defaultActiveKey={[firstUrl]}>
           {display}
         </Collapse>
       );

--- a/neuroscout/frontend/src/Report.tsx
+++ b/neuroscout/frontend/src/Report.tsx
@@ -27,12 +27,12 @@ const domainRoot = config.server_url;
 
 const Panel = Collapse.Panel;
 
-let getSub = (x: string) => {
-  let subRe = /sub-([a-zA-Z0-9]+)/;
+let getSub = (x: string, pre: string) => {
+  let subRe = new RegExp(`${pre}-([a-zA-Z0-9]+)`);
   let sub = '';
   let _sub = subRe.exec(x);
   if (_sub !== null) {
-    sub = _sub[0];
+    sub = _sub[1];
   }
   return sub;
 };
@@ -42,13 +42,17 @@ class Plots extends React.Component<{plots: string[]}, {}> {
       let display: any[] = [];
       let plots = this.props.plots.map((x, i) => {
         let url = 'https://' + x;
+        let sub = getSub(x, 'sub');
+        let run = getSub(x, 'run');
         // urls generated for localhost have None instead of localhost in url
         if (x.indexOf('None') === 0) {
           url = x.slice(4);
           url = domainRoot + url;
         }
         display.push(
-          <Panel header={<a href={url}>{url}</a>} key={'' + i}><img src={url} style={{width: '100%'}}/></Panel>
+          <Panel header={<a href={url}>{`Subject ${sub} Run ${run}`}</a>} key={'' + url}>
+            <img src={url} className="designMatrix"/>
+          </Panel>
         );
       });
       return(
@@ -64,7 +68,7 @@ class Matrices extends React.Component<{matrices: string[]}, {}> {
       let display: any[] = [];
       let matrices = this.props.matrices.map((x) => {
         let url = x;
-        let sub = getSub(x);
+        let sub = getSub(x, 'sub');
         if (x.indexOf('None') === 0) {
           url = x.slice(4);
         }
@@ -161,6 +165,8 @@ export class Report extends React.Component<ReportProps, ReportState> {
         state.reportTimestamp = res.generated_at;
         if (res.traceback) {
           state.reportTraceback = res.traceback;
+        } else {
+          state.reportTraceback = '';
         }
       } else if (res.status === 'FAILED') {
         state.reportTraceback = res.traceback;

--- a/neuroscout/frontend/src/Status.tsx
+++ b/neuroscout/frontend/src/Status.tsx
@@ -135,7 +135,7 @@ export class Submit extends React.Component<submitProps, {tosAgree: boolean, val
             }
         </ul>
         <Checkbox onChange={validateChange} checked={this.state.validate}>
-          Validate analysis bundle contents
+          Validate design matrix construction for all runs (reduces the chance of run-time errors, but can substantially increase bundle compilation time.)
         </Checkbox>
         <br/>
         <Checkbox onChange={onChange} checked={this.state.tosAgree}>

--- a/neuroscout/frontend/src/Status.tsx
+++ b/neuroscout/frontend/src/Status.tsx
@@ -135,7 +135,8 @@ export class Submit extends React.Component<submitProps, {tosAgree: boolean, val
             }
         </ul>
         <Checkbox onChange={validateChange} checked={this.state.validate}>
-          Validate design matrix construction for all runs (reduces the chance of run-time errors, but can substantially increase bundle compilation time.)
+          Validate design matrix construction for all runs (reduces the chance of run-time errors, but can
+          substantially increase bundle compilation time.)
         </Checkbox>
         <br/>
         <Checkbox onChange={onChange} checked={this.state.tosAgree}>

--- a/neuroscout/frontend/src/auth.actions.ts
+++ b/neuroscout/frontend/src/auth.actions.ts
@@ -5,6 +5,7 @@ var authActions = Reflux.createActions({
   'jwtFetch': {sync: false, asyncResult: true},
   'authenticate': {sync: false, asyncResult: true},
   'login': {},
+  'logout': {},
   'signup': {},
   'confirmLogout': {},
   'resetPassword': {},

--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -96,7 +96,6 @@ class CompileAnalysisResource(MethodResource):
 @doc(tags=['analysis'])
 class ReportResource(MethodResource):
     @doc(summary='Generate analysis reports.')
-    @owner_required
     def post(self, analysis, run_id=None):
         # Submit report generation
         analysis_json, pes_json = jsonify_analysis(analysis, run_id=run_id)

--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -96,6 +96,7 @@ class CompileAnalysisResource(MethodResource):
 @doc(tags=['analysis'])
 class ReportResource(MethodResource):
     @doc(summary='Generate analysis reports.')
+    @fetch_analysis
     def post(self, analysis, run_id=None):
         # Submit report generation
         analysis_json, pes_json = jsonify_analysis(analysis, run_id=run_id)

--- a/neuroscout/tests/api/test_dataset.py
+++ b/neuroscout/tests/api/test_dataset.py
@@ -1,27 +1,28 @@
 from tests.request_utils import decode_json
 
+
 def test_get_dataset(auth_client, add_local_task_json):
-	# List of datasets
-	resp = auth_client.get('/api/datasets')
-	assert resp.status_code == 200
-	dataset_list = decode_json(resp)
-	assert type(dataset_list) == list
+    # List of datasets
+    resp = auth_client.get('/api/datasets')
+    assert resp.status_code == 200
+    dataset_list = decode_json(resp)
+    assert type(dataset_list) == list
 
-	# Get first dataset
-	assert 'tasks' in dataset_list[0]
-	first_dataset_id = dataset_list[0]['id']
+    # Get first dataset
+    assert 'tasks' in dataset_list[0]
+    first_dataset_id = dataset_list[0]['id']
 
-	# Get first dataset by external id
-	resp = auth_client.get('/api/datasets/{}'.format(first_dataset_id))
-	assert resp.status_code == 200
-	dataset = decode_json(resp)
-	assert first_dataset_id == dataset['id']
-	assert dataset['tasks'][0]['name'] == 'bidstest'
-	assert dataset['tasks'][0]['summary'] == 'AV Movie'
-	assert dataset['name'] == 'bids_test'
-	assert dataset['summary'] == "A test dataset"
-	assert dataset['url'] == "https://github.com/adelavega/bids_test"
+    # Get first dataset by external id
+    resp = auth_client.get('/api/datasets/{}'.format(first_dataset_id))
+    assert resp.status_code == 200
+    dataset = decode_json(resp)
+    assert first_dataset_id == dataset['id']
+    assert dataset['tasks'][0]['name'] == 'bidstest'
+    assert dataset['tasks'][0]['summary'] == 'AV Movie'
+    assert dataset['name'] == 'bids_test'
+    assert dataset['summary'] == "A test dataset"
+    assert dataset['url'] == "https://github.com/adelavega/bids_test"
 
-	# Try getting nonexistent datset
-	resp = auth_client.get('/api/datasets/{}'.format('1324'))
-	assert resp.status_code == 404
+    # Try getting nonexistent datset
+    resp = auth_client.get('/api/datasets/{}'.format('1324'))
+    assert resp.status_code == 404


### PR DESCRIPTION
Closes #453 

I pushed a change to allow non-logged in users to request a report.

However, I think the issue is actually in the frontend code, because when I tried it without being logged in, only a `GET` was ever seen in the server logs, and never a `POST`. This is probably the original source of the bug.

Also, two more minor issue to fix in this PR:

- [x] Require users to define at least one contrast (otherwise reports will surely fail)
- [x] Clear out old errors. If I got an errors traceback, and fixed the error and succesfully create reports, the old traceback is still shown. 

@rwblair can you finish this PR off, plesae?