### PR TITLE
Speed up API

### DIFF
--- a/neuroscout/models/analysis.py
+++ b/neuroscout/models/analysis.py
@@ -51,7 +51,7 @@ class Analysis(db.Model):
     # If cloned, this is the parent analysis:
     parent_id = db.Column(db.Text, db.ForeignKey('analysis.hash_id'))
 
-    results = db.relationship('Result', backref='analysis')
+    results = db.relationship('Result', backref='analysis', lazy='dynamic')
     predictors = db.relationship('Predictor', secondary=analysis_predictor,
                                  backref='analysis')
     runs = db.relationship('Run', secondary='analysis_run')

--- a/neuroscout/models/analysis.py
+++ b/neuroscout/models/analysis.py
@@ -51,7 +51,7 @@ class Analysis(db.Model):
     # If cloned, this is the parent analysis:
     parent_id = db.Column(db.Text, db.ForeignKey('analysis.hash_id'))
 
-    results = db.relationship('Result', backref='analysis', lazy='dynamic')
+    results = db.relationship('Result', backref='analysis')
     predictors = db.relationship('Predictor', secondary=analysis_predictor,
                                  backref='analysis')
     runs = db.relationship('Run', secondary='analysis_run')

--- a/neuroscout/models/analysis.py
+++ b/neuroscout/models/analysis.py
@@ -54,7 +54,7 @@ class Analysis(db.Model):
     # If cloned, this is the parent analysis:
     parent_id = db.Column(db.Text, db.ForeignKey('analysis.hash_id'))
 
-    results = db.relationship('Result', backref='analysis', lazy='dynamic')
+    results = db.relationship('Result', backref='analysis')
     predictors = db.relationship('Predictor', secondary=analysis_predictor,
                                  backref='analysis')
     runs = db.relationship('Run', secondary='analysis_run')

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -20,11 +20,11 @@ class User(db.Model, UserMixin):
     active = db.Column(db.Boolean())  # If set to disabled, cannot access.
     confirmed_at = db.Column(db.DateTime())
     roles = db.relationship('Role', secondary=roles_users,
-                            backref=db.backref('users', lazy='dynamic'))
+                            backref=db.backref('users'))
     last_activity_at = db.Column(db.DateTime())
     last_activity_ip = db.Column(db.String(255))
 
-    analyses = db.relationship('Analysis', backref='user', lazy='dynamic')
+    analyses = db.relationship('Analysis', backref='user')
 
     def __repr__(self):
         return '<models.User[email=%s]>' % self.email

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -2,11 +2,12 @@ from database import db
 from flask_security import UserMixin, RoleMixin, SQLAlchemyUserDatastore
 
 # Association table between users and runs.
-roles_users = db.Table('roles_users',
-                       db.Column('user_id', db.Integer(), db.ForeignKey('user.id')),
-                       db.Column('role_id', db.Integer(), db.ForeignKey('role.id')))
+roles_users = db.Table(
+    'roles_users',
+    db.Column('user_id', db.Integer(), db.ForeignKey('user.id')),
+    db.Column('role_id', db.Integer(), db.ForeignKey('role.id')))
 
-## Authentication
+
 class User(db.Model, UserMixin):
     """" User model class """
     id = db.Column(db.Integer, primary_key=True)
@@ -16,23 +17,24 @@ class User(db.Model, UserMixin):
     picture = db.Column(db.Text)
 
     name = db.Column(db.String(40))
-    active = db.Column(db.Boolean()) # If set to disabled, cannot access.
+    active = db.Column(db.Boolean())  # If set to disabled, cannot access.
     confirmed_at = db.Column(db.DateTime())
     roles = db.relationship('Role', secondary=roles_users,
                             backref=db.backref('users', lazy='dynamic'))
     last_activity_at = db.Column(db.DateTime())
     last_activity_ip = db.Column(db.String(255))
 
-    analyses = db.relationship('Analysis', backref='user',
-                            lazy='dynamic')
+    analyses = db.relationship('Analysis', backref='user', lazy='dynamic')
 
     def __repr__(self):
         return '<models.User[email=%s]>' % self.email
+
 
 class Role(db.Model, RoleMixin):
     """ User roles """
     id = db.Column(db.Integer(), primary_key=True)
     name = db.Column(db.String(80), unique=True)
     description = db.Column(db.String(255))
+
 
 user_datastore = SQLAlchemyUserDatastore(db, User, Role)

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -19,11 +19,12 @@ class User(db.Model, UserMixin):
     active = db.Column(db.Boolean()) # If set to disabled, cannot access.
     confirmed_at = db.Column(db.DateTime())
     roles = db.relationship('Role', secondary=roles_users,
-                            backref=db.backref('users'))
+                            backref=db.backref('users', lazy='dynamic'))
     last_activity_at = db.Column(db.DateTime())
     last_activity_ip = db.Column(db.String(255))
 
-    analyses = db.relationship('Analysis', backref='user')
+    analyses = db.relationship('Analysis', backref='user',
+                            lazy='dynamic')
 
     def __repr__(self):
         return '<models.User[email=%s]>' % self.email

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -19,12 +19,11 @@ class User(db.Model, UserMixin):
     active = db.Column(db.Boolean()) # If set to disabled, cannot access.
     confirmed_at = db.Column(db.DateTime())
     roles = db.relationship('Role', secondary=roles_users,
-                            backref=db.backref('users', lazy='dynamic'))
+                            backref=db.backref('users'))
     last_activity_at = db.Column(db.DateTime())
     last_activity_ip = db.Column(db.String(255))
 
-    analyses = db.relationship('Analysis', backref='user',
-                            lazy='dynamic')
+    analyses = db.relationship('Analysis', backref='user')
 
     def __repr__(self):
         return '<models.User[email=%s]>' % self.email

--- a/neuroscout/models/dataset.py
+++ b/neuroscout/models/dataset.py
@@ -11,15 +11,11 @@ class Dataset(db.Model):
 	url = db.Column(db.Text) # External resource / link
 	active = db.Column(db.Boolean, default=True)
 	name = db.Column(db.Text, unique=True, nullable=False)
-	runs = db.relationship('Run', backref='dataset',
-	                        lazy='dynamic')
-	predictors = db.relationship('Predictor', backref='dataset',
-	                             lazy='dynamic')
+	runs = db.relationship('Run', backref='dataset')
+	predictors = db.relationship('Predictor', backref='dataset')
 
-	tasks = db.relationship('Task', backref='dataset',
-								lazy='dynamic')
-	analyses = db.relationship('Analysis', backref='dataset',
-	                            lazy='dynamic')
+	tasks = db.relationship('Task', backref='dataset')
+	analyses = db.relationship('Analysis', backref='dataset')
 	dataset_address = db.Column(db.Text)
 	preproc_address = db.Column(db.Text)
 	local_path = db.Column(db.Text)

--- a/neuroscout/models/dataset.py
+++ b/neuroscout/models/dataset.py
@@ -3,30 +3,31 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
 from .stimulus import Stimulus
 
+
 class Dataset(db.Model):
-	""" A BIDS dataset """
-	id = db.Column(db.Integer, primary_key=True)
-	description = db.Column(JSONB) # BIDS description
-	summary = db.Column(db.Text) # Hand crafted summary
-	url = db.Column(db.Text) # External resource / link
-	active = db.Column(db.Boolean, default=True)
-	name = db.Column(db.Text, unique=True, nullable=False)
-	runs = db.relationship('Run', backref='dataset')
-	predictors = db.relationship('Predictor', backref='dataset')
+    """ A BIDS dataset """
+    id = db.Column(db.Integer, primary_key=True)
+    description = db.Column(JSONB)  # BIDS description
+    summary = db.Column(db.Text)  # Hand crafted summary
+    url = db.Column(db.Text)  # External resource / link
+    active = db.Column(db.Boolean, default=True)
+    name = db.Column(db.Text, unique=True, nullable=False)
+    runs = db.relationship('Run', backref='dataset')
+    predictors = db.relationship('Predictor', backref='dataset')
 
-	tasks = db.relationship('Task', backref='dataset')
-	analyses = db.relationship('Analysis', backref='dataset')
-	dataset_address = db.Column(db.Text)
-	preproc_address = db.Column(db.Text)
-	local_path = db.Column(db.Text)
+    tasks = db.relationship('Task', backref='dataset')
+    analyses = db.relationship('Analysis', backref='dataset')
+    dataset_address = db.Column(db.Text)
+    preproc_address = db.Column(db.Text)
+    local_path = db.Column(db.Text)
 
-	@hybrid_property
-	def mimetypes(self):
-		""" List of mimetypes of stimuli in dataset """
-		return [s[0] for s in Stimulus.query.filter_by(
-			dataset_id=self.id).distinct('mimetype').values('mimetype')]
+    @hybrid_property
+    def mimetypes(self):
+        """ List of mimetypes of stimuli in dataset """
+        return [s[0] for s in Stimulus.query.filter_by(
+            dataset_id=self.id).distinct('mimetype').values('mimetype')]
 
-	# Meta-data, such as preprocessed history, etc...
+    # Meta-data, such as preprocessed history, etc...
 
-	def __repr__(self):
-	    return '<models.Dataset[name=%s]>' % self.name
+    def __repr__(self):
+        return '<models.Dataset[name=%s]>' % self.name

--- a/neuroscout/models/features.py
+++ b/neuroscout/models/features.py
@@ -19,7 +19,8 @@ class ExtractedFeature(db.Model):
 	created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
 	extractor_version = db.Column(db.Float, default=0.1)
 
-	extracted_events = db.relationship('ExtractedEvent', backref='extracted_feature')
+	extracted_events = db.relationship('ExtractedEvent', backref='extracted_feature',
+	                            		lazy='dynamic')
 	generated_predictors = db.relationship('Predictor',
 											backref='extracted_feature')
 

--- a/neuroscout/models/features.py
+++ b/neuroscout/models/features.py
@@ -19,8 +19,7 @@ class ExtractedFeature(db.Model):
 	created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
 	extractor_version = db.Column(db.Float, default=0.1)
 
-	extracted_events = db.relationship('ExtractedEvent', backref='extracted_feature',
-	                            		lazy='dynamic')
+	extracted_events = db.relationship('ExtractedEvent', backref='extracted_feature')
 	generated_predictors = db.relationship('Predictor',
 											backref='extracted_feature')
 

--- a/neuroscout/models/features.py
+++ b/neuroscout/models/features.py
@@ -2,40 +2,43 @@ from database import db
 import datetime
 from sqlalchemy.dialects.postgresql import JSONB
 
+
 class ExtractedFeature(db.Model):
-	""" Events extracted from a Stimulus using an Extractor"""
-	id = db.Column(db.Integer, primary_key=True)
-	# Hash of next three variables
-	sha1_hash = db.Column(db.Text, nullable=False)
-	extractor_name = db.Column(db.String)
-	extractor_parameters = db.Column(JSONB)
-	feature_name = db.Column(db.String)
-	original_name = db.Column(db.String) # Original feature_name
-	description = db.Column(db.String)
-	active = db.Column(db.Boolean)
-	modality = db.Column(db.String)
-	transformed = db.Column(db.Boolean, default=False)
+    """ Events extracted from a Stimulus using an Extractor"""
+    id = db.Column(db.Integer, primary_key=True)
+    # Hash of next three variables
+    sha1_hash = db.Column(db.Text, nullable=False)
+    extractor_name = db.Column(db.String)
+    extractor_parameters = db.Column(JSONB)
+    feature_name = db.Column(db.String)
+    original_name = db.Column(db.String)  # Original feature_name
+    description = db.Column(db.String)
+    active = db.Column(db.Boolean)
+    modality = db.Column(db.String)
+    transformed = db.Column(db.Boolean, default=False)
 
-	created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
-	extractor_version = db.Column(db.Float, default=0.1)
+    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
+    extractor_version = db.Column(db.Float, default=0.1)
 
-	extracted_events = db.relationship('ExtractedEvent', backref='extracted_feature',
-	                            		lazy='dynamic')
-	generated_predictors = db.relationship('Predictor',
-											backref='extracted_feature')
+    extracted_events = db.relationship(
+        'ExtractedEvent', backref='extracted_feature')
+    generated_predictors = db.relationship(
+        'Predictor', backref='extracted_feature')
 
-	def __repr__(self):
-	    return '<models.ExtractedFeature[feature_name=%s]>' % self.feature_name
+    def __repr__(self):
+        return '<models.ExtractedFeature[feature_name=%s]>' % self.feature_name
+
 
 class ExtractedEvent(db.Model):
-	""" Events extracted from a Stimuli"""
-	id = db.Column(db.Integer, primary_key=True)
-	onset = db.Column(db.Float)
-	duration = db.Column(db.Float)
-	value = db.Column(db.String, nullable=False)
-	history = db.Column(db.String)
-	object_id = db.Column(db.Integer)
+    """ Events extracted from a Stimuli"""
+    id = db.Column(db.Integer, primary_key=True)
+    onset = db.Column(db.Float)
+    duration = db.Column(db.Float)
+    value = db.Column(db.String, nullable=False)
+    history = db.Column(db.String)
+    object_id = db.Column(db.Integer)
 
-	stimulus_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'), nullable=False)
-	ef_id = db.Column(db.Integer, db.ForeignKey(ExtractedFeature.id),
-						   nullable=False)
+    stimulus_id = db.Column(
+        db.Integer, db.ForeignKey('stimulus.id'), nullable=False)
+    ef_id = db.Column(
+        db.Integer, db.ForeignKey(ExtractedFeature.id), nullable=False)

--- a/neuroscout/models/group.py
+++ b/neuroscout/models/group.py
@@ -9,7 +9,8 @@ class GroupPredictor(db.Model):
 
     dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'), nullable=False)
 
-    values = db.relationship('GroupPredictorValue', backref='group_predictor')
+    values = db.relationship('GroupPredictorValue', backref='group_predictor',
+    							lazy='dynamic')
     def __repr__(self):
         return '<models.GroupPredictor[name=%s]>' % self.name
 

--- a/neuroscout/models/group.py
+++ b/neuroscout/models/group.py
@@ -1,18 +1,21 @@
 from database import db
 
+
 class GroupPredictor(db.Model):
     """ Group-level predictors, e.g. across subjects, sessions, etc... """
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text, nullable=False)
-    description = db.Column(db.Text) # Where to get this from?
-    level = db.Column(db.String, nullable=False) # Session? Subject?
+    description = db.Column(db.Text)  # Where to get this from?
+    level = db.Column(db.String, nullable=False)  # Session? Subject?
 
-    dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'), nullable=False)
+    dataset_id = db.Column(
+        db.Integer, db.ForeignKey('dataset.id'), nullable=False)
 
-    values = db.relationship('GroupPredictorValue', backref='group_predictor',
-    							lazy='dynamic')
+    values = db.relationship('GroupPredictorValue', backref='group_predictor')
+
     def __repr__(self):
         return '<models.GroupPredictor[name=%s]>' % self.name
+
 
 class GroupPredictorValue(db.Model):
     """ Contains values of GroupPredictor for every Run.

--- a/neuroscout/models/group.py
+++ b/neuroscout/models/group.py
@@ -9,8 +9,7 @@ class GroupPredictor(db.Model):
 
     dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'), nullable=False)
 
-    values = db.relationship('GroupPredictorValue', backref='group_predictor',
-    							lazy='dynamic')
+    values = db.relationship('GroupPredictorValue', backref='group_predictor')
     def __repr__(self):
         return '<models.GroupPredictor[name=%s]>' % self.name
 

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -16,7 +16,7 @@ class Predictor(db.Model):
 
     predictor_events = db.relationship('PredictorEvent', backref='predictor')
 
-    run_statistics = db.relationship('PredictorRun')
+    predictor_run = db.relationship('PredictorRun')
     active = db.Column(db.Boolean, default=True)  # Actively display or not
 
     def __repr__(self):

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -1,6 +1,5 @@
 from database import db
 import statistics
-from sqlalchemy import func, Numeric, cast
 
 
 class Predictor(db.Model):

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -1,6 +1,4 @@
 from database import db
-import statistics
-
 
 class Predictor(db.Model):
     """ Instantiation of a predictor in a dataset.
@@ -54,23 +52,3 @@ class PredictorRun(db.Model):
     run_id = db.Column(db.Integer, db.ForeignKey('run.id'), primary_key=True)
     predictor_id = db.Column(db.Integer, db.ForeignKey('predictor.id'),
                              primary_key=True)
-
-    def stat_property(function):
-        @property
-        def wrapper(self):
-            val_query = PredictorEvent.query.filter_by(
-                    run_id=self.run_id,
-                    predictor_id=self.predictor_id).with_entities('value')
-            try:
-                return function(self, [float(a[0]) for a in val_query])
-            except ValueError:
-                return None
-        return wrapper
-
-    @stat_property
-    def mean(self, values):
-        return statistics.mean(values)
-
-    @stat_property
-    def stdev(self, values):
-        return statistics.stdev(values)

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -1,5 +1,6 @@
 from database import db
 import statistics
+from sqlalchemy import func, Numeric, cast
 
 
 class Predictor(db.Model):
@@ -16,10 +17,46 @@ class Predictor(db.Model):
                            nullable=False)
     ef_id = db.Column(db.Integer, db.ForeignKey('extracted_feature.id'))
 
-    predictor_events = db.relationship('PredictorEvent', backref='predictor')
+    predictor_events = db.relationship('PredictorEvent', backref='predictor',
+                                       lazy='dynamic')
 
     run_statistics = db.relationship('PredictorRun')
     active = db.Column(db.Boolean, default=True)  # Actively display or not
+
+    @property
+    def non_null(self):
+        return self.predictor_events.filter(
+            ~PredictorEvent.value.in_(['nan', 'n/a', 'NaN']))
+
+    @property
+    def num_na(self):
+        return self.predictor_events.filter(
+            PredictorEvent.value.in_(['nan', 'n/a', 'NaN'])).count()
+
+    def apply_func(self, method):
+        """ Apply function to non-null Numeric castable values """
+        return self.non_null.with_entities(
+            getattr(func, method)(
+                cast(func.nullif(
+                    func.regexp_replace(
+                        PredictorEvent.value, ".*[^0-9.]+.*", ""), ""),
+                     Numeric))).scalar()
+
+    @property
+    def max(self):
+        return self.apply_func('max')
+
+    @property
+    def min(self):
+        return self.apply_func('min')
+
+    @property
+    def mean(self):
+        return self.apply_func('avg')
+
+    @property
+    def stddev(self):
+        return self.apply_func('stddev')
 
     def __repr__(self):
         return '<models.Predictor[name=%s]>' % self.name

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -1,6 +1,5 @@
 from database import db
 import statistics
-from sqlalchemy import func, Numeric, cast
 
 
 class Predictor(db.Model):
@@ -17,46 +16,10 @@ class Predictor(db.Model):
                            nullable=False)
     ef_id = db.Column(db.Integer, db.ForeignKey('extracted_feature.id'))
 
-    predictor_events = db.relationship('PredictorEvent', backref='predictor',
-                                       lazy='dynamic')
+    predictor_events = db.relationship('PredictorEvent', backref='predictor')
 
     run_statistics = db.relationship('PredictorRun')
     active = db.Column(db.Boolean, default=True)  # Actively display or not
-
-    @property
-    def non_null(self):
-        return self.predictor_events.filter(
-            ~PredictorEvent.value.in_(['nan', 'n/a', 'NaN']))
-
-    @property
-    def num_na(self):
-        return self.predictor_events.filter(
-            PredictorEvent.value.in_(['nan', 'n/a', 'NaN'])).count()
-
-    def apply_func(self, method):
-        """ Apply function to non-null Numeric castable values """
-        return self.non_null.with_entities(
-            getattr(func, method)(
-                cast(func.nullif(
-                    func.regexp_replace(
-                        PredictorEvent.value, ".*[^0-9.]+.*", ""), ""),
-                     Numeric))).scalar()
-
-    @property
-    def max(self):
-        return self.apply_func('max')
-
-    @property
-    def min(self):
-        return self.apply_func('min')
-
-    @property
-    def mean(self):
-        return self.apply_func('avg')
-
-    @property
-    def stddev(self):
-        return self.apply_func('stddev')
 
     def __repr__(self):
         return '<models.Predictor[name=%s]>' % self.name

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -17,46 +17,10 @@ class Predictor(db.Model):
                            nullable=False)
     ef_id = db.Column(db.Integer, db.ForeignKey('extracted_feature.id'))
 
-    predictor_events = db.relationship('PredictorEvent', backref='predictor',
-                                       lazy='dynamic')
+    predictor_events = db.relationship('PredictorEvent', backref='predictor')
 
     run_statistics = db.relationship('PredictorRun')
     active = db.Column(db.Boolean, default=True)  # Actively display or not
-
-    @property
-    def non_null(self):
-        return self.predictor_events.filter(
-            ~PredictorEvent.value.in_(['nan', 'n/a', 'NaN']))
-
-    @property
-    def num_na(self):
-        return self.predictor_events.filter(
-            PredictorEvent.value.in_(['nan', 'n/a', 'NaN'])).count()
-
-    def apply_func(self, method):
-        """ Apply function to non-null Numeric castable values """
-        return self.non_null.with_entities(
-            getattr(func, method)(
-                cast(func.nullif(
-                    func.regexp_replace(
-                        PredictorEvent.value, ".*[^0-9.]+.*", ""), ""),
-                     Numeric))).scalar()
-
-    @property
-    def max(self):
-        return self.apply_func('max')
-
-    @property
-    def min(self):
-        return self.apply_func('min')
-
-    @property
-    def mean(self):
-        return self.apply_func('avg')
-
-    @property
-    def stddev(self):
-        return self.apply_func('stddev')
 
     def __repr__(self):
         return '<models.Predictor[name=%s]>' % self.name

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -1,14 +1,17 @@
 from database import db
 
 # Association table between analysis and run.
-analysis_run = db.Table('analysis_run',
-                       db.Column('analysis_id', db.Integer(), db.ForeignKey('analysis.id')),
-                       db.Column('run_id', db.Integer(), db.ForeignKey('run.id')))
+analysis_run = db.Table(
+    'analysis_run',
+    db.Column('analysis_id', db.Integer(), db.ForeignKey('analysis.id')),
+    db.Column('run_id', db.Integer(), db.ForeignKey('run.id')))
+
 
 class Run(db.Model):
     """ A single scan run. The basic unit of fMRI analysis. """
     __table_args__ = (
-        db.UniqueConstraint('session', 'subject', 'number', 'task_id', 'dataset_id'),
+        db.UniqueConstraint(
+            'session', 'subject', 'number', 'task_id', 'dataset_id'),
     )
     id = db.Column(db.Integer, primary_key=True)
     session = db.Column(db.Text)
@@ -18,21 +21,24 @@ class Run(db.Model):
     number = db.Column(db.Integer)
 
     duration = db.Column(db.Float)
-    func_path = db.Column(db.Text) # Relative to fmriprep root
-    mask_path = db.Column(db.Text) # Relative to fmriprep root
+    func_path = db.Column(db.Text)  # Relative to fmriprep root
+    mask_path = db.Column(db.Text)  # Relative to fmriprep root
 
     task_id = db.Column(db.Integer, db.ForeignKey('task.id'),
-                           nullable=False)
-    dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'), nullable=False)
+                        nullable=False)
+    dataset_id = db.Column(
+        db.Integer, db.ForeignKey('dataset.id'), nullable=False)
 
     prs = db.relationship('PredictorRun',
                           cascade='delete')
     gpv = db.relationship('GroupPredictorValue',
                           cascade='delete')
-    predictor_events = db.relationship('PredictorEvent', backref='run',
-                                        lazy='dynamic', cascade='delete')
-    analyses = db.relationship('Analysis',
-                            secondary='analysis_run',
-                            lazy='dynamic')
+    predictor_events = db.relationship(
+        'PredictorEvent', backref='run',
+        lazy='dynamic', cascade='delete')
+    analyses = db.relationship(
+        'Analysis', secondary='analysis_run', lazy='dynamic')
+
     def __repr__(self):
-        return '<models.Run[task={} sub={} sess={} number={}]>'.format(self.task, self.subject, self.session, self.number)
+        return '<models.Run[task={} sub={} sess={} number={}]>'.format(
+            self.task, self.subject, self.session, self.number)

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -21,8 +21,6 @@ class Run(db.Model):
     number = db.Column(db.Integer)
 
     duration = db.Column(db.Float)
-    func_path = db.Column(db.Text)  # Relative to fmriprep root
-    mask_path = db.Column(db.Text)  # Relative to fmriprep root
 
     task_id = db.Column(db.Integer, db.ForeignKey('task.id'),
                         nullable=False)

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -30,8 +30,9 @@ class Run(db.Model):
     gpv = db.relationship('GroupPredictorValue',
                           cascade='delete')
     predictor_events = db.relationship('PredictorEvent', backref='run',
-                                        cascade='delete')
+                                        lazy='dynamic', cascade='delete')
     analyses = db.relationship('Analysis',
-                            secondary='analysis_run')
+                            secondary='analysis_run',
+                            lazy='dynamic')
     def __repr__(self):
         return '<models.Run[task={} sub={} sess={} number={}]>'.format(self.task, self.subject, self.session, self.number)

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -30,9 +30,8 @@ class Run(db.Model):
     gpv = db.relationship('GroupPredictorValue',
                           cascade='delete')
     predictor_events = db.relationship('PredictorEvent', backref='run',
-                                        lazy='dynamic', cascade='delete')
+                                        cascade='delete')
     analyses = db.relationship('Analysis',
-                            secondary='analysis_run',
-                            lazy='dynamic')
+                            secondary='analysis_run')
     def __repr__(self):
         return '<models.Run[task={} sub={} sess={} number={}]>'.format(self.task, self.subject, self.session, self.number)

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -35,9 +35,9 @@ class Run(db.Model):
                           cascade='delete')
     predictor_events = db.relationship(
         'PredictorEvent', backref='run',
-        lazy='dynamic', cascade='delete')
+        cascade='delete')
     analyses = db.relationship(
-        'Analysis', secondary='analysis_run', lazy='dynamic')
+        'Analysis', secondary='analysis_run')
 
     def __repr__(self):
         return '<models.Run[task={} sub={} sess={} number={}]>'.format(

--- a/neuroscout/models/stimulus.py
+++ b/neuroscout/models/stimulus.py
@@ -29,9 +29,9 @@ class Stimulus(db.Model):
 	converter_name = db.Column(db.String)
 	converter_parameters = db.Column(db.Text)
 
-	extracted_events = db.relationship('ExtractedEvent', lazy='dynamic')
+	extracted_events = db.relationship('ExtractedEvent')
 	runs = db.relationship('Run',secondary='run_stimulus')
-	run_stimuli = db.relationship('RunStimulus', lazy='dynamic',
+	run_stimuli = db.relationship('RunStimulus',
 							   	  backref='stimulus')
 
 	def __repr__(self):

--- a/neuroscout/models/stimulus.py
+++ b/neuroscout/models/stimulus.py
@@ -29,9 +29,9 @@ class Stimulus(db.Model):
 	converter_name = db.Column(db.String)
 	converter_parameters = db.Column(db.Text)
 
-	extracted_events = db.relationship('ExtractedEvent')
+	extracted_events = db.relationship('ExtractedEvent', lazy='dynamic')
 	runs = db.relationship('Run',secondary='run_stimulus')
-	run_stimuli = db.relationship('RunStimulus',
+	run_stimuli = db.relationship('RunStimulus', lazy='dynamic',
 							   	  backref='stimulus')
 
 	def __repr__(self):

--- a/neuroscout/models/stimulus.py
+++ b/neuroscout/models/stimulus.py
@@ -1,50 +1,50 @@
 from database import db
 
+
 class Stimulus(db.Model):
-	""" A unique stimulus. A stimulus may occur at different points in time,
-		and perhaps even across different datasets. """
-	__table_args__ = (
-	    db.UniqueConstraint('sha1_hash', 'dataset_id', 'converter_name',
-							'parent_id'),
-	)
+    """ A unique stimulus. A stimulus may occur at different points in time,
+        and perhaps even across different datasets. """
+    __table_args__ = (
+        db.UniqueConstraint('sha1_hash', 'dataset_id', 'converter_name',
+                            'parent_id'),
+    )
 
-	__table_args__ = (
-  		db.CheckConstraint('NOT(path IS NULL AND content IS NULL)'),
-	)
+    __table_args__ = (
+          db.CheckConstraint('NOT(path IS NULL AND content IS NULL)'),
+    )
 
-	id = db.Column(db.Integer, primary_key=True)
-	sha1_hash = db.Column(db.Text, nullable=False)
-	mimetype = db.Column(db.Text, nullable=False)
+    id = db.Column(db.Integer, primary_key=True)
+    sha1_hash = db.Column(db.Text, nullable=False)
+    mimetype = db.Column(db.Text, nullable=False)
 
-	path = db.Column(db.Text)
-	content = db.Column(db.Text)
+    path = db.Column(db.Text)
+    content = db.Column(db.Text)
 
-	dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'),
-						   nullable=False)
+    dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'),
+                           nullable=False)
 
-	active = db.Column(db.Boolean, nullable=False, default=True)
+    active = db.Column(db.Boolean, nullable=False, default=True)
 
-	# For converted stimuli
-	parent_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))
-	converter_name = db.Column(db.String)
-	converter_parameters = db.Column(db.Text)
+    # For converted stimuli
+    parent_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))
+    converter_name = db.Column(db.String)
+    converter_parameters = db.Column(db.Text)
 
-	extracted_events = db.relationship('ExtractedEvent', lazy='dynamic')
-	runs = db.relationship('Run',secondary='run_stimulus')
-	run_stimuli = db.relationship('RunStimulus', lazy='dynamic',
-							   	  backref='stimulus')
+    extracted_events = db.relationship('ExtractedEvent')
+    runs = db.relationship('Run', secondary='run_stimulus')
+    run_stimuli = db.relationship('RunStimulus', backref='stimulus')
 
-	def __repr__(self):
-	    return '<models.Stimulus[hash={}]>'.format(self.sha1_hash)
+    def __repr__(self):
+        return '<models.Stimulus[hash={}]>'.format(self.sha1_hash)
 
 
 class RunStimulus(db.Model):
-	""" Run Stimulus association table """
-	__table_args__ = (
-	    db.UniqueConstraint('stimulus_id', 'run_id', 'onset'),
-	)
-	id = db.Column(db.Integer, primary_key=True)
-	stimulus_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))
-	run_id = db.Column(db.Integer, db.ForeignKey('run.id'))
-	onset = db.Column(db.Float)
-	duration = db.Column(db.Float)
+    """ Run Stimulus association table """
+    __table_args__ = (
+        db.UniqueConstraint('stimulus_id', 'run_id', 'onset'),
+    )
+    id = db.Column(db.Integer, primary_key=True)
+    stimulus_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))
+    run_id = db.Column(db.Integer, db.ForeignKey('run.id'))
+    onset = db.Column(db.Float)
+    duration = db.Column(db.Float)

--- a/neuroscout/populate/ingest.py
+++ b/neuroscout/populate/ingest.py
@@ -215,28 +215,9 @@ def add_task(task_name, dataset_name=None, local_path=None,
         else:
             run_model.duration = scan_length
 
-        path_patterns = [
-            'sub-{subject}/[ses-{session}/]func/sub-{subject}_'
-            '[ses-{session}_]task-{task}_[acq-{acquisition}_]'
-            '[run-{run}_][space-{space}_][desc-{desc}_]{suffix}.nii.gz']
-
-        run_model.func_path = layout.build_path(
-            {'suffix': 'bold', 'desc': 'preproc',
-             'space': 'MNI152NLin2009cAsym', **entities},
-            path_patterns=path_patterns)
-        run_model.mask_path = layout.build_path(
-            {'suffix': 'mask', 'desc': 'brain',
-             'space': 'MNI152NLin2009cAsym', **entities},
-            path_patterns=path_patterns)
-
         # Put back as int
         if 'run' in entities:
             entities['run'] = int(entities['run'])
-
-        # Confirm remote address exists:
-        if preproc_address is not None:
-            remote_resource_exists(preproc_address, run_model.func_path)
-            remote_resource_exists(preproc_address, run_model.mask_path)
 
         """ Extract Predictors"""
         # Assert event files exist (for DataLad)

--- a/neuroscout/populate/utils.py
+++ b/neuroscout/populate/utils.py
@@ -6,7 +6,8 @@ import hashlib
 import warnings
 from pathlib import Path
 
-def hash_stim(stim, blocksize = 65536):
+
+def hash_stim(stim, blocksize=65536):
     """ Hash a pliers stimulus """
     if isinstance(stim, Path):
         stim = stim.as_posix()
@@ -32,6 +33,7 @@ def hash_stim(stim, blocksize = 65536):
 
     return hasher.hexdigest()
 
+
 def hash_data(data):
     """" Hashes data or string """
     if isinstance(data, str):
@@ -42,6 +44,7 @@ def hash_data(data):
     hasher.update(data)
 
     return hasher.hexdigest()
+
 
 def remote_resource_exists(base_address, resource, raise_exception=False,
                  content_type='binary/octet-stream'):
@@ -57,18 +60,3 @@ def remote_resource_exists(base_address, resource, raise_exception=False,
             return False
 
     return True
-
-# For updating paths in the db
-# def get_entities(run, **kwargs):
-#      entities = {entity : getattr(run, entity)
-#          for entity in ['subject', 'session', 'acquisition']
-#          if entity in run.__dict__ and getattr(run, entity) is not None}
-#      entities['task'] = run.task.name
-#      if 'number' in run.__dict__ and run.number is not None:
-#              entities['run'] = str(run.number)
-#      if 'run' in entities:
-#          entities['run']= entities['run'].zfill(2)
-#      return {**kwargs, **entities}
-# for r in ms.Run.query.all():
-#     ...:     r.func_path = layout.build_path(get_entities(r, suffix='bold', desc='preproc', space='MNI152NLin2009cAsym'), path_patterns=
-#     ...: path_patterns)

--- a/neuroscout/resources/analysis/endpoints.py
+++ b/neuroscout/resources/analysis/endpoints.py
@@ -90,7 +90,7 @@ class AnalysisFillResource(AnalysisMethodResource):
 
         if not analysis.runs:
             #  Set to all runs in dataset
-            fields['runs'] = analysis.dataset.runs.all()
+            fields['runs'] = analysis.dataset.runs
             fields['model'] = analysis.model
             fields['model']["Input"] = {}
 

--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -1,32 +1,17 @@
 from flask_apispec import doc, use_kwargs, MethodResource, marshal_with
 from database import db
 from flask import current_app
-from sqlalchemy.dialects import postgresql
 from models import PredictorEvent, Report
 from worker import celery_app
 import webargs as wa
 from marshmallow import fields
 from ..utils import owner_required, abort, fetch_analysis
+from ..predictor import dump_pe
 from .schemas import (AnalysisFullSchema, AnalysisResourcesSchema,
                       ReportSchema, AnalysisCompiledSchema)
 import celery.states as states
 from utils import put_record
 import datetime
-
-
-def dump_pe(pes):
-    """ Serialize PredictorEvents, with *SPEED*, using core SQL.
-    Warning: relies on attributes being in correct order. """
-    statement = str(pes.statement.compile(dialect=postgresql.dialect()))
-    params = pes.statement.compile(dialect=postgresql.dialect()).params
-    res = db.session.connection().execute(statement, params)
-    return [{
-      'onset': r[1],
-      'duration': r[2],
-      'value':  r[3],
-      'run_id': r[5],
-      'predictor_id': r[6]
-      } for r in res]
 
 
 def jsonify_analysis(analysis, run_id=None):

--- a/neuroscout/resources/analysis/schemas.py
+++ b/neuroscout/resources/analysis/schemas.py
@@ -105,10 +105,6 @@ class AnalysisResourcesSchema(Schema):
         'DatasetSchema', only='dataset_address', attribute='dataset')
     dataset_name = fields.Nested(
         'DatasetSchema', only='name', attribute='dataset')
-    func_paths = fields.Nested(
-        'RunSchema', many=True, only='func_path', attribute='runs')
-    mask_paths = fields.Nested(
-        'RunSchema', many=True, only='mask_path', attribute='runs')
 
 
 class AnalysisCompiledSchema(Schema):

--- a/neuroscout/resources/dataset.py
+++ b/neuroscout/resources/dataset.py
@@ -5,39 +5,50 @@ from models import Dataset
 from .utils import first_or_404, make_cache_key
 from core import cache
 
+
 class DatasetSchema(Schema):
-	""" Dataset validation schema. """
-	id = fields.Int()
-	name = fields.Str(description='Dataset name')
-	description = fields.Dict(description='Dataset description from BIDS dataset')
-	summary = fields.Str(description='Dataset summary description')
-	url = fields.Str(descrption='Link to external resources')
-	mimetypes = fields.List(fields.Str(),
-                         description='Dataset mimetypes/modalities')
-	runs = fields.Nested('RunSchema', many=True, only='id')
-	tasks = fields.Nested('TaskSchema', many=True, only=['id', 'name', 'summary', 'num_runs'])
-	dataset_address = fields.Str(description='BIDS Dataset remote address')
-	preproc_address = fields.Str(description='Preprocessed data remote address')
+    """ Dataset validation schema. """
+    id = fields.Int()
+    name = fields.Str(
+        description='Dataset name')
+    description = fields.Dict(
+        description='Dataset description from BIDS dataset')
+    summary = fields.Str(
+        description='Dataset summary description')
+    url = fields.Str(
+        descrption='Link to external resources')
+    mimetypes = fields.List(
+        fields.Str(), description='Dataset mimetypes/modalities')
+    runs = fields.Nested(
+        'RunSchema', many=True, only='id')
+    tasks = fields.Nested(
+        'TaskSchema', many=True, only=['id', 'name', 'summary', 'num_runs'])
+    dataset_address = fields.Str(
+        description='BIDS Dataset remote address')
+    preproc_address = fields.Str(
+        description='Preprocessed data remote address')
+
 
 class DatasetResource(MethodResource):
-	@doc(tags=['dataset'], summary='Get dataset by id.')
-	@cache.cached(60 * 60 * 24 * 300, key_prefix=make_cache_key)
-	@marshal_with(DatasetSchema)
-	def get(self, dataset_id):
-		return first_or_404(Dataset.query.filter_by(id=dataset_id))
+    @doc(tags=['dataset'], summary='Get dataset by id.')
+    @cache.cached(60 * 60 * 24 * 300, key_prefix=make_cache_key)
+    @marshal_with(DatasetSchema)
+    def get(self, dataset_id):
+        return first_or_404(Dataset.query.filter_by(id=dataset_id))
+
 
 class DatasetListResource(MethodResource):
-	@doc(tags=['dataset'], summary='Returns list of datasets.')
-	@use_kwargs({
-	    'active_only': wa.fields.Boolean(missing=True,
-	                description="Return only active Datasets")
-	    },
-	    locations=['query'])
-	@cache.cached(60 * 60 * 24 * 300, key_prefix=make_cache_key)
-	@marshal_with(DatasetSchema(many=True,
-								exclude=['dataset_address', 'preproc_address']))
-	def get(self, **kwargs):
-		query = {}
-		if kwargs.pop('active_only'):
-			query['active'] = True
-		return Dataset.query.filter_by(**query).all()
+    @doc(tags=['dataset'], summary='Returns list of datasets.')
+    @use_kwargs({
+        'active_only': wa.fields.Boolean(
+            missing=True, description="Return only active Datasets")
+        },
+        locations=['query'])
+    @cache.cached(60 * 60 * 24 * 300, key_prefix=make_cache_key)
+    @marshal_with(DatasetSchema(
+        many=True, exclude=['dataset_address', 'preproc_address']))
+    def get(self, **kwargs):
+        query = {}
+        if kwargs.pop('active_only'):
+            query['active'] = True
+        return Dataset.query.filter_by(**query).all()

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -131,4 +131,4 @@ class PredictorEventListResource(MethodResource):
         for param in kwargs:
             query = query.filter(
                 getattr(PredictorEvent, param).in_(kwargs[param]))
-        return dump_pe(query.all())
+        return dump_pe(query)

--- a/neuroscout/resources/run.py
+++ b/neuroscout/resources/run.py
@@ -4,50 +4,50 @@ import webargs as wa
 from models import Run
 from .utils import first_or_404
 
-class RunSchema(Schema):
-	id = fields.Int()
-	session = fields.Str(description='Session number')
-	acquisition = fields.Str(description='Acquisition')
-	subject = fields.Str(description='Subject id')
-	number = fields.Int(description='Run id')
-	duration = fields.Number(description='Total run duration in seconds.')
-	dataset_id = fields.Int(description='Dataset run belongs to.')
-	task = fields.Nested('TaskSchema', only='id',
-	                    description="Task id and name")
-	func_path = fields.Str(description='Path of functional file')
-	mask_path = fields.Str(description='Path of brain mask')
 
-exclude = ['func_path', 'mask_path']
+class RunSchema(Schema):
+    id = fields.Int()
+    session = fields.Str(description='Session number')
+    acquisition = fields.Str(description='Acquisition')
+    subject = fields.Str(description='Subject id')
+    number = fields.Int(description='Run id')
+    duration = fields.Number(description='Total run duration in seconds.')
+    dataset_id = fields.Int(description='Dataset run belongs to.')
+    task = fields.Nested(
+        'TaskSchema', only='id', description="Task id and name")
+
+
 class RunResource(MethodResource):
     @doc(tags=['run'], summary='Get run by id.')
-    @marshal_with(RunSchema(exclude=exclude))
+    @marshal_with(RunSchema())
     def get(self, run_id):
         return first_or_404(Run.query.filter_by(id=run_id))
+
 
 class RunListResource(MethodResource):
     @doc(tags=['run'], summary='Returns list of runs.')
     @use_kwargs({
-    	'session': wa.fields.DelimitedList(fields.Str(),
-                                        description='Session number(s).'),
-        'number': wa.fields.DelimitedList(fields.Int(),
-                                          description='Run number(s).'),
-        'task_id': wa.fields.DelimitedList(fields.Int(),
-                                        description='Task id(s).'),
-        'subject': wa.fields.DelimitedList(fields.Str(),
-                                           description='Subject id(s).'),
+        'session': wa.fields.DelimitedList(
+            fields.Str(), description='Session number(s).'),
+        'number': wa.fields.DelimitedList(
+            fields.Int(), description='Run number(s).'),
+        'task_id': wa.fields.DelimitedList(
+            fields.Int(), description='Task id(s).'),
+        'subject': wa.fields.DelimitedList(
+            fields.Str(), description='Subject id(s).'),
         'dataset_id': wa.fields.Int(description='Dataset id.'),
     }, locations=['query'])
-    @marshal_with(RunSchema(many=True, exclude=exclude))
+    @marshal_with(RunSchema(many=True))
     def get(self, **kwargs):
         try:
             dataset = kwargs.pop('dataset_id')
         except KeyError:
-        	dataset = None
+            dataset = None
 
         query = Run.query
         for param in kwargs:
-        	query = query.filter(getattr(Run, param).in_(kwargs[param]))
+            query = query.filter(getattr(Run, param).in_(kwargs[param]))
 
         if dataset:
-        	query = query.join('dataset').filter_by(id=dataset)
+            query = query.join('dataset').filter_by(id=dataset)
         return query.all()

--- a/neuroscout/tests/api/test_analyses.py
+++ b/neuroscout/tests/api/test_analyses.py
@@ -46,7 +46,6 @@ def test_get(session, auth_client, add_analysis):
         first_analysis_id))
     assert resp.status_code == 200
     assert 'dataset_address' in decode_json(resp)
-    assert 'mask_paths' in decode_json(resp)
     assert 'preproc_address' in decode_json(resp)
 
 

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -1,4 +1,6 @@
 from tests.request_utils import decode_json
+
+
 def test_get_predictor(auth_client, extract_features):
     # List of predictors
     resp = auth_client.get('/api/predictors')
@@ -11,13 +13,6 @@ def test_get_predictor(auth_client, extract_features):
     assert 'name' in rt
     assert rt['description'] == "How long it takes to react!"
     pred_id = rt['id']
-
-    # Test auto-calculated properties
-    assert  rt['mean'] == 173.625
-    assert  rt['max'] == 230.0
-    assert  rt['min'] == 120.0
-    assert  round(rt['stddev']) == 41
-    assert  rt['num_na'] == 0
 
     # Check that derivative event is in there
     assert len([p for p in pred_list if p['name'] == 'rating']) > 0
@@ -37,25 +32,26 @@ def test_get_predictor(auth_client, extract_features):
     dataset_id = ds[0]['id']
     run_id = str(ds[0]['runs'][0])
 
-    resp = auth_client.get('/api/predictors', params={'run_id' : run_id})
+    resp = auth_client.get('/api/predictors', params={'run_id': run_id})
     assert resp.status_code == 200
     pred_select = decode_json(resp)
     assert type(pred_select) == list
 
-    resp = auth_client.get('/api/predictors', params={'run_id' : '123123'})
+    resp = auth_client.get('/api/predictors', params={'run_id': '123123'})
     assert resp.status_code == 200
     assert len(decode_json(resp)) == 0
 
     # Test filtering by dataset
-    resp = auth_client.get('/api/predictors', params={'dataset_id' : dataset_id})
+    resp = auth_client.get(
+        '/api/predictors', params={'dataset_id': dataset_id})
     assert resp.status_code == 200
     pred_select = decode_json(resp)
     assert type(pred_select) == list
     assert len(pred_select) == 4
 
     # Test filtering by multiple parameters
-    resp = auth_client.get('/api/predictors', params={'name': 'rt',
-        'run_id': run_id})
+    resp = auth_client.get(
+        '/api/predictors', params={'name': 'rt', 'run_id': run_id})
     assert resp.status_code == 200
     pred_p = decode_json(resp)
     assert len(pred_p) == 1
@@ -63,22 +59,25 @@ def test_get_predictor(auth_client, extract_features):
     assert pred_p[0]['source'] == 'events'
 
     # Test extracted_feature
-    resp = auth_client.get('/api/predictors', params={'name': 'Brightness',
-        'run_id': run_id})
+    resp = auth_client.get(
+        '/api/predictors', params={'name': 'Brightness', 'run_id': run_id})
     assert resp.status_code == 200
     pred_p = decode_json(resp)
     assert 'extracted_feature' in pred_p[0]
-    assert pred_p[0]['extracted_feature']['description'] == 'Brightness of an image.'
+    assert pred_p[0]['extracted_feature']['description'] == \
+        'Brightness of an image.'
     assert pred_p[0]['source'] == 'extracted'
     assert pred_p[0]['extracted_feature']['modality'] == 'image'
 
 
 def test_get_rextracted(auth_client, reextract):
     run_id = decode_json(
-        auth_client.get('/api/runs', params={'number' : '1', 'subject': '01'}))[0]['id']
+        auth_client.get(
+            '/api/runs', params={'number': '1', 'subject': '01'}))[0]['id']
     resp = auth_client.get('/api/predictors', params={
         'run_id': run_id, 'newest': 'false'})
     assert len(decode_json(resp)) == 5
+
 
 def test_get_predictor_data(auth_client, add_task):
     # List of predictors
@@ -89,9 +88,9 @@ def test_get_predictor_data(auth_client, add_task):
 
     pe = pe_list[0]
     # Get PEs only for one run
-    resp = auth_client.get('/api/predictor-events',
-                           params={'predictor_id' : pe['predictor_id'],
-                                 'run_id' : pe['run_id']})
+    resp = auth_client.get(
+        '/api/predictor-events',
+        params={'predictor_id': pe['predictor_id'], 'run_id': pe['run_id']})
 
     assert resp.status_code == 200
     pe_list_filt = decode_json(resp)

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -32,8 +32,6 @@ def test_dataset_ingestion(session, add_task):
     assert 'TaskName' in run_model.task.description
     assert run_model.task.description['RepetitionTime'] == 2.0
 
-    assert run_model.func_path == 'sub-01/func/sub-01_task-bidstest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz'
-
     # Test properties of first run's predictor events
     assert len(run_model.predictor_events) == 12
     assert Predictor.query.count() == len(dataset_model.predictors) == 3

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -24,7 +24,7 @@ def test_dataset_ingestion(session, add_task):
     session.rollback()
 
     # Test properties of Run
-    assert Run.query.count() == dataset_model.runs.count() == 4
+    assert Run.query.count() == len(dataset_model.runs) == 4
     run_model = dataset_model.runs.filter_by(number='1', subject='01').first()
     assert run_model.dataset_id == dataset_model.id
     assert 'TaskName' in run_model.task.description
@@ -79,7 +79,7 @@ def test_json_local_dataset(session, add_local_task_json):
 
     # Test properties of Run
     assert Run.query.filter_by(dataset_id=add_local_task_json).count() \
-        == dataset_model.runs.count() == 1
+        == len(dataset_model.runs) == 1
     predictor = Predictor.query.filter_by(name='rt').first()
     assert predictor.predictor_events.count() == 4
 

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -52,7 +52,7 @@ def test_dataset_ingestion(session, add_task):
     assert 167.25 in [p.mean for p in predictor.run_statistics]
 
     # Test predictor event
-    predictor_event = predictor.predictor_events.first()
+    predictor_event = predictor.predictor_events[0]
     assert predictor_event.value is not None
     assert predictor_event.onset is not None
 
@@ -68,7 +68,7 @@ def test_dataset_ingestion(session, add_task):
     assert GroupPredictor.query.filter_by(name='sex').count() == 1
 
     gpv = GroupPredictor.query.filter_by(name='sex').one().values
-    assert gpv.count() == 4
+    assert len(gpv) == 4
     assert 'F' in [v.value for v in gpv]
 
 
@@ -211,7 +211,7 @@ def test_external_text(get_data_path, add_task):
     first_stim = [s for s in data if s.content == 'no'][0]
 
     assert len(data) == 2
-    assert first_stim.run_stimuli.count() == 4
+    assert len(first_stim.run_stimuli) == 4
     assert 2.2 in [s.onset for s in first_stim.run_stimuli]
 
 

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -35,7 +35,7 @@ def test_dataset_ingestion(session, add_task):
     assert run_model.func_path == 'sub-01/func/sub-01_task-bidstest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz'
 
     # Test properties of first run's predictor events
-    assert run_model.predictor_events.count() == 12
+    assert len(run_model.predictor_events) == 12
     assert Predictor.query.count() == len(dataset_model.predictors) == 3
 
     pred_names = [p.name for p in Predictor.query.all()]
@@ -43,7 +43,7 @@ def test_dataset_ingestion(session, add_task):
     assert 'rating' in pred_names  # Derivative event
 
     predictor = Predictor.query.filter_by(name='rt').first()
-    assert predictor.predictor_events.count() == 16
+    assert len(predictor.predictor_events) == 16
     assert predictor.source == 'events'
     assert predictor.original_name == 'reaction_time'
 
@@ -83,7 +83,7 @@ def test_json_local_dataset(session, add_local_task_json):
     assert Run.query.filter_by(dataset_id=add_local_task_json).count() \
         == len(dataset_model.runs) == 1
     predictor = Predictor.query.filter_by(name='rt').first()
-    assert predictor.predictor_events.count() == 4
+    assert len(predictor.predictor_events) == 4
 
     # Test that Stimiuli were extracted
     assert Stimulus.query.count() == 5
@@ -102,7 +102,7 @@ def test_json_local_dataset(session, add_local_task_json):
 
     num_bright = ExtractedFeature.query.filter_by(feature_name='num_bright')
     assert num_bright.count() == 1
-    assert num_bright.first().extracted_events.count() == 3
+    assert len(num_bright.first().extracted_events) == 3
 
     for ee in num_bright.first().extracted_events:
         assert ee.value == '1'
@@ -128,7 +128,7 @@ def test_extracted_features(session, add_task, extract_features):
     assert ef_b.description == "Brightness of an image."
 
     # Check that the number of features extracted is the same as Stimuli
-    assert ef_b.extracted_events.count() == Stimulus.query.count()
+    assert len(ef_b.extracted_events) == Stimulus.query.count()
 
     # Check for sensical value
     assert isclose(float(session.query(func.max(PredictorEvent.value)).join(

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -25,7 +25,9 @@ def test_dataset_ingestion(session, add_task):
 
     # Test properties of Run
     assert Run.query.count() == len(dataset_model.runs) == 4
-    run_model = dataset_model.runs.filter_by(number='1', subject='01').first()
+    run_model = [
+        r for r in dataset_model.runs
+        if r.subject == '01' and r.number == 1][0]
     assert run_model.dataset_id == dataset_model.id
     assert 'TaskName' in run_model.task.description
     assert run_model.task.description['RepetitionTime'] == 2.0

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -45,10 +45,6 @@ def test_dataset_ingestion(session, add_task):
     assert predictor.source == 'events'
     assert predictor.original_name == 'reaction_time'
 
-    # Test run summary statistics
-    assert len(predictor.run_statistics) == 4
-    assert 167.25 in [p.mean for p in predictor.run_statistics]
-
     # Test predictor event
     predictor_event = predictor.predictor_events[0]
     assert predictor_event.value is not None

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -36,7 +36,7 @@ def test_dataset_ingestion(session, add_task):
 
     # Test properties of first run's predictor events
     assert run_model.predictor_events.count() == 12
-    assert Predictor.query.count() == dataset_model.predictors.count() == 3
+    assert Predictor.query.count() == len(dataset_model.predictors) == 3
 
     pred_names = [p.name for p in Predictor.query.all()]
     assert 'rt' in pred_names

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -1,232 +1,243 @@
 import pytest
-import os
 from sqlalchemy import func
-from models import (Analysis, User, Dataset, Predictor, Stimulus, Run,
-					RunStimulus, Result, ExtractedFeature, PredictorEvent,
-					GroupPredictor, Task)
+from models import (
+    Analysis, User, Dataset, Predictor, Stimulus, Run, RunStimulus, Result,
+    ExtractedFeature, PredictorEvent, GroupPredictor, Task)
 
 from numpy import isclose
 from populate.convert import ingest_text_stimuli
 from populate.modify import update_annotations
 
+
 def test_dataset_ingestion(session, add_task):
-	dataset_model = Dataset.query.filter_by(id=add_task).one()
+    dataset_model = Dataset.query.filter_by(id=add_task).one()
 
-	# Test mimetypes
-	assert 'image/jpeg' in dataset_model.mimetypes
-	assert 'bidstest' == dataset_model.tasks[0].name
+    # Test mimetypes
+    assert 'image/jpeg' in dataset_model.mimetypes
+    assert 'bidstest' == dataset_model.tasks[0].name
 
-	# Try adding dataset without a name
-	with pytest.raises(Exception) as excinfo:
-		session.add(Dataset())
-		session.commit()
-	assert 'not-null constraint' in str(excinfo)
-	session.rollback()
+    # Try adding dataset without a name
+    with pytest.raises(Exception) as excinfo:
+        session.add(Dataset())
+        session.commit()
+    assert 'not-null constraint' in str(excinfo)
+    session.rollback()
 
-	# Test properties of Run
-	assert Run.query.count() == dataset_model.runs.count() == 4
-	run_model =  dataset_model.runs.filter_by(number='1', subject='01').first()
-	assert run_model.dataset_id == dataset_model.id
-	assert 'TaskName' in run_model.task.description
-	assert run_model.task.description['RepetitionTime'] == 2.0
+    # Test properties of Run
+    assert Run.query.count() == dataset_model.runs.count() == 4
+    run_model = dataset_model.runs.filter_by(number='1', subject='01').first()
+    assert run_model.dataset_id == dataset_model.id
+    assert 'TaskName' in run_model.task.description
+    assert run_model.task.description['RepetitionTime'] == 2.0
 
-	assert run_model.func_path == 'sub-01/func/sub-01_task-bidstest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz'
+    assert run_model.func_path == 'sub-01/func/sub-01_task-bidstest_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz'
 
-	# Test properties of first run's predictor events
-	assert run_model.predictor_events.count() == 12
-	assert Predictor.query.count() == dataset_model.predictors.count() == 3
+    # Test properties of first run's predictor events
+    assert run_model.predictor_events.count() == 12
+    assert Predictor.query.count() == dataset_model.predictors.count() == 3
 
-	pred_names = [p.name for p in Predictor.query.all()]
-	assert 'rt' in pred_names
-	assert 'rating' in pred_names ## Derivative event
+    pred_names = [p.name for p in Predictor.query.all()]
+    assert 'rt' in pred_names
+    assert 'rating' in pred_names  # Derivative event
 
-	predictor = Predictor.query.filter_by(name='rt').first()
-	assert predictor.predictor_events.count() == 16
-	assert predictor.source == 'events'
-	assert predictor.original_name == 'reaction_time'
+    predictor = Predictor.query.filter_by(name='rt').first()
+    assert predictor.predictor_events.count() == 16
+    assert predictor.source == 'events'
+    assert predictor.original_name == 'reaction_time'
 
-	# Test run summary statistics
-	assert len(predictor.run_statistics) == 4
-	assert 167.25 in [p.mean for p in predictor.run_statistics]
+    # Test run summary statistics
+    assert len(predictor.run_statistics) == 4
+    assert 167.25 in [p.mean for p in predictor.run_statistics]
 
-	# Test predictor event
-	predictor_event = predictor.predictor_events.first()
-	assert predictor_event.value is not None
-	assert predictor_event.onset is not None
+    # Test predictor event
+    predictor_event = predictor.predictor_events.first()
+    assert predictor_event.value is not None
+    assert predictor_event.onset is not None
 
-	# Test that Stimiuli were extracted
-	assert Stimulus.query.count() == 4
+    # Test that Stimiuli were extracted
+    assert Stimulus.query.count() == 4
 
-	# and that they were associated with runs (4 runs )
-	assert RunStimulus.query.count() == \
-		Stimulus.query.count() * Run.query.count() == 16
+    # and that they were associated with runs (4 runs )
+    assert RunStimulus.query.count() == \
+        Stimulus.query.count() * Run.query.count() == 16
 
-	# Test participants.tsv ingestion
-	assert GroupPredictor.query.count() == 3
-	assert GroupPredictor.query.filter_by(name='sex').count() == 1
+    # Test participants.tsv ingestion
+    assert GroupPredictor.query.count() == 3
+    assert GroupPredictor.query.filter_by(name='sex').count() == 1
 
-	gpv = GroupPredictor.query.filter_by(name='sex').one().values
-	assert gpv.count() == 4
-	assert 'F' in [v.value for v in gpv]
+    gpv = GroupPredictor.query.filter_by(name='sex').one().values
+    assert gpv.count() == 4
+    assert 'F' in [v.value for v in gpv]
+
 
 def test_json_local_dataset(session, add_local_task_json):
-	dataset_model = Dataset.query.filter_by(id=add_local_task_json).one()
+    dataset_model = Dataset.query.filter_by(id=add_local_task_json).one()
 
-	# Test mimetypes
-	assert 'image/jpeg' in dataset_model.mimetypes
-	assert 'bidstest' == dataset_model.tasks[0].name
+    # Test mimetypes
+    assert 'image/jpeg' in dataset_model.mimetypes
+    assert 'bidstest' == dataset_model.tasks[0].name
 
-	# Test properties of Run
-	assert Run.query.filter_by(dataset_id=add_local_task_json).count() \
-			== dataset_model.runs.count() == 1
-	predictor = Predictor.query.filter_by(name='rt').first()
-	assert predictor.predictor_events.count() == 4
+    # Test properties of Run
+    assert Run.query.filter_by(dataset_id=add_local_task_json).count() \
+        == dataset_model.runs.count() == 1
+    predictor = Predictor.query.filter_by(name='rt').first()
+    assert predictor.predictor_events.count() == 4
 
-	# Test that Stimiuli were extracted
-	assert Stimulus.query.count() == 5
+    # Test that Stimiuli were extracted
+    assert Stimulus.query.count() == 5
 
-	# Test participants.tsv ingestion
-	assert GroupPredictor.query.filter_by(
-			dataset_id=add_local_task_json).count() == 3
+    # Test participants.tsv ingestion
+    assert GroupPredictor.query.filter_by(
+            dataset_id=add_local_task_json).count() == 3
 
-	# Test that stimuli were converted
-	converted_stim = [s for s in Stimulus.query if s.parent_id is not None][0]
-	assert converted_stim.converter_name == 'TesseractConverter'
+    # Test that stimuli were converted
+    converted_stim = [s for s in Stimulus.query if s.parent_id is not None][0]
+    assert converted_stim.converter_name == 'TesseractConverter'
 
-	bright = ExtractedFeature.query.filter_by(
-		feature_name='Brightness').one()
-	assert bright.original_name == 'brightness'
+    bright = ExtractedFeature.query.filter_by(
+        feature_name='Brightness').one()
+    assert bright.original_name == 'brightness'
 
-	num_bright = ExtractedFeature.query.filter_by(feature_name='num_bright')
-	assert num_bright.count() == 1
-	assert num_bright.first().extracted_events.count() == 3
+    num_bright = ExtractedFeature.query.filter_by(feature_name='num_bright')
+    assert num_bright.count() == 1
+    assert num_bright.first().extracted_events.count() == 3
 
-	for ee in num_bright.first().extracted_events:
-		assert ee.value == '1'
+    for ee in num_bright.first().extracted_events:
+        assert ee.value == '1'
 
 
 def test_local_update(update_local_json):
-	assert update_local_json is not None
-	assert ExtractedFeature.query.count() == 6
+    assert update_local_json is not None
+    assert ExtractedFeature.query.count() == 6
+
 
 def test_extracted_features(session, add_task, extract_features):
-	""" This tests feature extraction from a remote dataset"""
-	assert ExtractedFeature.query.count() == 2
+    """ This tests feature extraction from a remote dataset"""
+    assert ExtractedFeature.query.count() == 2
 
-	extractor_names = [ee.extractor_name for ee in ExtractedFeature.query.all()]
-	assert 'BrightnessExtractor' in extractor_names
-	assert 'VibranceExtractor' in extractor_names
+    extractor_names = [ee.extractor_name
+                       for ee in ExtractedFeature.query.all()]
+    assert 'BrightnessExtractor' in extractor_names
+    assert 'VibranceExtractor' in extractor_names
 
-	ef_b = ExtractedFeature.query.filter_by(extractor_name='BrightnessExtractor').one()
-	assert ef_b.extractor_version is not None
-	assert ef_b.description == "Brightness of an image."
+    ef_b = ExtractedFeature.query.filter_by(
+        extractor_name='BrightnessExtractor').one()
+    assert ef_b.extractor_version is not None
+    assert ef_b.description == "Brightness of an image."
 
-	# Check that the number of features extracted is the same as Stimuli
-	assert ef_b.extracted_events.count() == Stimulus.query.count()
+    # Check that the number of features extracted is the same as Stimuli
+    assert ef_b.extracted_events.count() == Stimulus.query.count()
 
-	# Check for sensical value
-	assert isclose(float(session.query(func.max(PredictorEvent.value)).join(
-		Predictor).filter_by(ef_id=ef_b.id).one()[0]), 0.88, 0.1)
+    # Check for sensical value
+    assert isclose(float(session.query(func.max(PredictorEvent.value)).join(
+        Predictor).filter_by(ef_id=ef_b.id).one()[0]), 0.88, 0.1)
 
-	# And that a sensical onset was extracted
-	assert session.query(func.max(PredictorEvent.onset)).join(
-		Predictor).filter_by(ef_id=ef_b.id).one()[0] == 25.0
+    # And that a sensical onset was extracted
+    assert session.query(func.max(PredictorEvent.onset)).join(
+        Predictor).filter_by(ef_id=ef_b.id).one()[0] == 25.0
 
-	# Test that Predictors were created from EF
-	pred = Predictor.query.filter_by(ef_id=ef_b.id).one()
-	assert pred.name == "Brightness"
-	assert pred.source == "extracted"
+    # Test that Predictors were created from EF
+    pred = Predictor.query.filter_by(ef_id=ef_b.id).one()
+    assert pred.name == "Brightness"
+    assert pred.source == "extracted"
 
-	# Test that a Predictor was not made for vibrance (hidden)
-	ef_v = ExtractedFeature.query.filter_by(
-		extractor_name='VibranceExtractor').one()
-	assert Predictor.query.filter_by(ef_id=ef_v.id).count() == 0
+    # Test that a Predictor was not made for vibrance (hidden)
+    ef_v = ExtractedFeature.query.filter_by(
+        extractor_name='VibranceExtractor').one()
+    assert Predictor.query.filter_by(ef_id=ef_v.id).count() == 0
 
-	# Test that vibrance's name was changed using regex
-	assert ef_v.feature_name == "vib"
-	assert ef_v.description == "vib of an image."
+    # Test that vibrance's name was changed using regex
+    assert ef_v.feature_name == "vib"
+    assert ef_v.description == "vib of an image."
 
-	# Test that sharpness was annotated regardless (even without entry)
-	ef_v = ExtractedFeature.query.filter_by(
-		extractor_name='SharpnessExtractor').count() == 1
+    # Test that sharpness was annotated regardless (even without entry)
+    ef_v = ExtractedFeature.query.filter_by(
+        extractor_name='SharpnessExtractor').count() == 1
+
 
 def test_analysis(session, add_analysis, add_predictor):
-	# Number of entries
-	assert Analysis.query.count() == 1
+    # Number of entries
+    assert Analysis.query.count() == 1
 
-	first_analysis = Analysis.query.first()
-	assert User.query.filter_by(id=first_analysis.user_id).count() == 1
+    first_analysis = Analysis.query.first()
+    assert User.query.filter_by(id=first_analysis.user_id).count() == 1
 
-	# Add relationship to a predictor
-	pred = Predictor.query.filter_by(id = add_predictor).one()
-	first_analysis.predictors = [pred]
-	session.commit()
-	assert Predictor.query.filter_by(id = add_predictor).one().analysis[0].id \
-		== first_analysis.id
+    # Add relationship to a predictor
+    pred = Predictor.query.filter_by(id=add_predictor).one()
+    first_analysis.predictors = [pred]
+    session.commit()
+    assert Predictor.query.filter_by(id=add_predictor).one().analysis[0].id \
+        == first_analysis.id
 
-	# Try adding analysis without a name
-	with pytest.raises(Exception) as excinfo:
-		session.add(Analysis())
-		session.commit()
-	assert 'not-null constraint' in str(excinfo)
-	session.rollback()
+    # Try adding analysis without a name
+    with pytest.raises(Exception) as excinfo:
+        session.add(Analysis())
+        session.commit()
+    assert 'not-null constraint' in str(excinfo)
+    session.rollback()
 
-	# Try cloning analysis
-	user = User.query.filter_by(id=first_analysis.user_id).one()
-	clone = first_analysis.clone(user)
-	session.add(clone)
-	session.commit()
+    # Try cloning analysis
+    user = User.query.filter_by(id=first_analysis.user_id).one()
+    clone = first_analysis.clone(user)
+    session.add(clone)
+    session.commit()
 
-	assert clone.id > first_analysis.id
-	assert clone.name == first_analysis.name
+    assert clone.id > first_analysis.id
+    assert clone.name == first_analysis.name
+
 
 def test_result(add_result):
-	assert Result.query.count() == 1
+    assert Result.query.count() == 1
+
 
 def test_external_text(get_data_path, add_task):
-	filename = (get_data_path / 'fake_transcript.csv').as_posix()
+    filename = (get_data_path / 'fake_transcript.csv').as_posix()
 
-	dataset_model = Dataset.query.filter_by(id=add_task).one()
-	task_name = Task.query.filter_by(dataset_id=add_task).one().name
+    dataset_model = Dataset.query.filter_by(id=add_task).one()
+    ds_id = dataset_model.id
+    task_name = Task.query.filter_by(dataset_id=add_task).one().name
 
-	stim = [s for s in Stimulus.query.filter_by(dataset_id=dataset_model.id).all() if 'obama' in s.path][0]
+    stim = [s
+            for s in Stimulus.query.filter_by(dataset_id=ds_id).all()
+            if 'obama' in s.path][0]
 
-	ingest_text_stimuli(filename, dataset_model.name, task_name, stim.id,
-						transformer='FakeTextExtraction')
+    ingest_text_stimuli(filename, dataset_model.name, task_name, stim.id,
+                        transformer='FakeTextExtraction')
 
-	data = [s for s in Stimulus.query.all() if s.content is not None]
+    data = [s for s in Stimulus.query.all() if s.content is not None]
 
-	first_stim = [s for s in data if s.content == 'no'][0]
+    first_stim = [s for s in data if s.content == 'no'][0]
 
-	assert len(data) == 2
-	assert first_stim.run_stimuli.count() == 4
-	assert 2.2 in [s.onset for s in first_stim.run_stimuli]
+    assert len(data) == 2
+    assert first_stim.run_stimuli.count() == 4
+    assert 2.2 in [s.onset for s in first_stim.run_stimuli]
+
 
 def test_update_schema(session, add_task, extract_features):
-	bright = ExtractedFeature.query.filter_by(
-		feature_name='Brightness').one()
-	bright.feature_name = 'whatever'
-	session.commit()
-	assert 	ExtractedFeature.query.filter_by(
-			feature_name='whatever').count() == 1
+    bright = ExtractedFeature.query.filter_by(
+        feature_name='Brightness').one()
+    bright.feature_name = 'whatever'
+    session.commit()
+    assert ExtractedFeature.query.filter_by(
+        feature_name='whatever').count() == 1
 
-	update_annotations(mode='features')
+    update_annotations(mode='features')
 
-	assert 	ExtractedFeature.query.filter_by(
-			feature_name='whatever').count() == 0
-	bright = ExtractedFeature.query.filter_by(
-		feature_name='Brightness').one()
-	assert bright.feature_name == 'Brightness'
-	assert bright.original_name == 'brightness'
+    assert ExtractedFeature.query.filter_by(
+        feature_name='whatever').count() == 0
+    bright = ExtractedFeature.query.filter_by(
+        feature_name='Brightness').one()
+    assert bright.feature_name == 'Brightness'
+    assert bright.original_name == 'brightness'
 
-	predictor = Predictor.query.filter_by(name='rt').first()
-	predictor.name = 'REACTION_TIME'
-	session.commit()
+    predictor = Predictor.query.filter_by(name='rt').first()
+    predictor.name = 'REACTION_TIME'
+    session.commit()
 
-	assert Predictor.query.filter_by(name='REACTION_TIME').count() == 1
+    assert Predictor.query.filter_by(name='REACTION_TIME').count() == 1
 
-	update_annotations()
+    update_annotations()
 
-	assert Predictor.query.filter_by(name='REACTION_TIME').count() == 0
-	predictor = Predictor.query.filter_by(name='rt').first()
-	assert predictor.name == 'rt'
+    assert Predictor.query.filter_by(name='REACTION_TIME').count() == 0
+    predictor = Predictor.query.filter_by(name='rt').first()
+    assert predictor.name == 'rt'


### PR DESCRIPTION
WIP. Closes #475 

Removing dynamic non-lazy joins and on the fly stats on Predictors took the response of `/api/predictors` from 38s to 3s.