### PR TITLE
Ignore query string order. Closes # 473

### DIFF
--- a/neuroscout/resources/dataset.py
+++ b/neuroscout/resources/dataset.py
@@ -31,7 +31,7 @@ class DatasetSchema(Schema):
 
 class DatasetResource(MethodResource):
     @doc(tags=['dataset'], summary='Get dataset by id.')
-    @cache.cached(60 * 60 * 24 * 300 query_string=True)
+    @cache.cached(60 * 60 * 24 * 300, query_string=True)
     @marshal_with(DatasetSchema)
     def get(self, dataset_id):
         return first_or_404(Dataset.query.filter_by(id=dataset_id))

--- a/neuroscout/resources/dataset.py
+++ b/neuroscout/resources/dataset.py
@@ -31,7 +31,7 @@ class DatasetSchema(Schema):
 
 class DatasetResource(MethodResource):
     @doc(tags=['dataset'], summary='Get dataset by id.')
-    @cache.cached(60 * 60 * 24 * 300, key_prefix=make_cache_key)
+    @cache.cached(60 * 60 * 24 * 300 query_string=True)
     @marshal_with(DatasetSchema)
     def get(self, dataset_id):
         return first_or_404(Dataset.query.filter_by(id=dataset_id))
@@ -44,7 +44,7 @@ class DatasetListResource(MethodResource):
             missing=True, description="Return only active Datasets")
         },
         locations=['query'])
-    @cache.cached(60 * 60 * 24 * 300, key_prefix=make_cache_key)
+    @cache.cached(60 * 60 * 24 * 300, query_string=True)
     @marshal_with(DatasetSchema(
         many=True, exclude=['dataset_address', 'preproc_address']))
     def get(self, **kwargs):

--- a/neuroscout/resources/dataset.py
+++ b/neuroscout/resources/dataset.py
@@ -2,7 +2,7 @@ from flask_apispec import MethodResource, marshal_with, doc, use_kwargs
 import webargs as wa
 from marshmallow import Schema, fields
 from models import Dataset
-from .utils import first_or_404, make_cache_key
+from .utils import first_or_404
 from core import cache
 
 

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -108,7 +108,7 @@ class PredictorListResource(MethodResource):
             description="Return only newest Predictor by name")
         },
         locations=['query'])
-    @cache.cached(key_prefix=make_cache_key)
+    @cache.cached(60 * 60 * 24 * 300, query_string=True)
     @marshal_with(PredictorSchema(many=True))
     def get(self, **kwargs):
         newest = kwargs.pop('newest')
@@ -117,7 +117,6 @@ class PredictorListResource(MethodResource):
 
 class PredictorEventListResource(MethodResource):
     @doc(tags=['predictors'], summary='Get events for predictor(s)',)
-    @cache.cached(60 * 60 * 24 * 300, key_prefix=make_cache_key)
     @use_kwargs({
         'run_id': wa.fields.DelimitedList(
             fields.Int(),
@@ -126,6 +125,7 @@ class PredictorEventListResource(MethodResource):
             fields.Int(),
             description="Predictor id(s)"),
     }, locations=['query'])
+    @cache.cached(60 * 60 * 24 * 300, query_string=True)
     def get(self, **kwargs):
         query = PredictorEvent.query
         for param in kwargs:

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -2,7 +2,7 @@ from marshmallow import Schema, fields, post_dump
 import webargs as wa
 from flask_apispec import MethodResource, marshal_with, use_kwargs, doc
 from models import Predictor, PredictorEvent, PredictorRun
-from .utils import first_or_404, make_cache_key
+from .utils import first_or_404
 from sqlalchemy import func
 from database import db
 from sqlalchemy.dialects import postgresql

--- a/neuroscout/resources/utils.py
+++ b/neuroscout/resources/utils.py
@@ -4,16 +4,19 @@ from flask_apispec import doc
 import datetime
 from webargs.flaskparser import parser
 from models import Analysis
+from flask import current_app
 
 import celery.states as states
 from worker import celery_app
 from database import db
 from utils import put_record
 
+
 def abort(code, message=''):
     """ JSONified abort """
     from flask import abort, make_response
     abort(make_response(jsonify(message=message), code))
+
 
 def first_or_404(query):
     """ Return first instance of query or throw a 404 error """
@@ -23,10 +26,11 @@ def first_or_404(query):
     else:
         abort(404, 'Resource not found')
 
+
 def update_analysis_status(analysis, commit=True):
     """ Checks celery for updates to analysis status and results """
-    if not analysis.status in ["DRAFT", "PASSED", "SUBMITTING"] and \
-        analysis.compile_task_id is not None:
+    if analysis.status not in ["DRAFT", "PASSED", "SUBMITTING"] and \
+       analysis.compile_task_id is not None:
         res = celery_app.AsyncResult(analysis.compile_task_id)
         if res.state == states.FAILURE:
             analysis.status = "FAILED"
@@ -41,6 +45,7 @@ def update_analysis_status(analysis, commit=True):
             db.session.commit()
     return analysis
 
+
 def fetch_analysis(function):
     """ Given kwarg analysis_id, fetch analysis model and insert as kwargs """
     def wrapper(*args, **kwargs):
@@ -51,11 +56,12 @@ def fetch_analysis(function):
         return function(*args, **kwargs)
     return wrapper
 
+
 def auth_required(function):
     """" A valid JWT is required to access """
     @doc(params={"authorization": {
-    "in": "header", "required": True,
-    "description": "Format:  JWT {authorization_token}"}})
+        "in": "header", "required": True,
+        "description": "Format:  JWT {authorization_token}"}})
     @jwt_required()
     def wrapper(*args, **kwargs):
         # Record activity time and IP
@@ -73,6 +79,7 @@ def auth_required(function):
         return function(*args, **kwargs)
     return wrapper
 
+
 def owner_required(function):
     """ A JWT matching the user id of the analysis is required,
         assumes analysis id is second argument, and replaces id with
@@ -82,15 +89,13 @@ def owner_required(function):
     def wrapper(*args, **kwargs):
         if current_identity.id != kwargs['analysis'].user_id:
             return abort(
-                401, {"message" : "You are not the owner of this analysis."})
+                401, {"message": "You are not the owner of this analysis."})
         return function(*args, **kwargs)
     return wrapper
+
 
 @parser.error_handler
 def handle_request_parsing_error(err):
     code = getattr(err, 'status_code', 400)
     msg = getattr(err, 'messages', 'Invalid Request')
     abort(code, msg)
-
-def make_cache_key(*args, **kwargs):
-    return request.url

--- a/neuroscout/resources/utils.py
+++ b/neuroscout/resources/utils.py
@@ -4,7 +4,6 @@ from flask_apispec import doc
 import datetime
 from webargs.flaskparser import parser
 from models import Analysis
-from flask import current_app
 
 import celery.states as states
 from worker import celery_app


### PR DESCRIPTION
Closes #473 

I'm removing our custom cache key function, and replacing it with the build in query string support. This will ignore the order of the arguments. 

Actually ignoring invalid arguments is not as easy, because the libraries that parse the query string, and cache don't talk. We could add this functionality but I honestly think its not necessary because its rare we'll get so many invalid requests (especially if using Swagger or `pyns`) as to cause a problem. In addition, flask-caching handles the disk size of the cache, so unless that becomes a problem, I think we are OK. 