### PR TITLE
Fix/forrest

### DIFF
--- a/neuroscout/config/datasets/forrest.json
+++ b/neuroscout/config/datasets/forrest.json
@@ -20,11 +20,11 @@
           "exclude_predictors": ["lasttrigger", "audiotime", "videotime", "frameidx", "trigger", "respiratory", "cardiac", "pupil_dil", "x", "y", "movieframe_idx"]
         },
         "filters": {
-          "subject": ["01","03", "04", "05", "06", "09", "10", "14", "15", "16", "18", "19", "20"],
-          "session": "movie"
+          "subject": ["16"],
+          "session": "movie",
+          "run": [1, 3, 4]
         }
       }
     }
   }
 }
-

--- a/neuroscout/models/dataset.py
+++ b/neuroscout/models/dataset.py
@@ -13,8 +13,8 @@ class Dataset(db.Model):
     active = db.Column(db.Boolean, default=True)
     name = db.Column(db.Text, unique=True, nullable=False)
     runs = db.relationship('Run', backref='dataset')
-    predictors = db.relationship('Predictor', backref='dataset')
-
+    predictors = db.relationship('Predictor', backref='dataset',
+                                 lazy='dynamic')
     tasks = db.relationship('Task', backref='dataset')
     analyses = db.relationship('Analysis', backref='dataset')
     dataset_address = db.Column(db.Text)

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -33,7 +33,8 @@ class Run(db.Model):
                           cascade='delete')
     predictor_events = db.relationship(
         'PredictorEvent', backref='run',
-        cascade='delete')
+        cascade='delete',
+        lazy='dynamic')
     analyses = db.relationship(
         'Analysis', secondary='analysis_run')
 

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -33,7 +33,7 @@ def test_dataset_ingestion(session, add_task):
     assert run_model.task.description['RepetitionTime'] == 2.0
 
     # Test properties of first run's predictor events
-    assert len(run_model.predictor_events) == 12
+    assert run_model.predictor_events.count() == 12
     assert Predictor.query.count() == len(dataset_model.predictors) == 3
 
     pred_names = [p.name for p in Predictor.query.all()]

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -34,7 +34,7 @@ def test_dataset_ingestion(session, add_task):
 
     # Test properties of first run's predictor events
     assert run_model.predictor_events.count() == 12
-    assert Predictor.query.count() == len(dataset_model.predictors) == 3
+    assert Predictor.query.count() == dataset_model.predictors.count() == 3
 
     pred_names = [p.name for p in Predictor.query.all()]
     assert 'rt' in pred_names


### PR DESCRIPTION
This PR is making some minor changes used to track down the inconsistencies in studyforrest.

Turns out 3 runs were not fully ingested and were missing confounds, which are not ingested. 

I should probably make a function to make it easier to diagnose these sort of things (list of missing predictors per run--- some should be OK to have missing such as `cosine12` but others should be).