### PR TITLE
443 389 preload predictors consistent form err

### DIFF
--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -240,10 +240,6 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
           return data;
         })
         .then((data: ApiAnalysis) => {
-          // tslint:disable-next-line:no-console
-          console.log('maybe here?');
-          // tslint:disable-next-line:no-console
-          console.log(data);
           if (editableStatus.includes(data.status)) {
             this.setState({model: this.buildModel()});
           } else if (data.model !== undefined) {
@@ -366,10 +362,6 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
       imgInput.Task = task[0];
     }
 
-    // tslint:disable-next-line:no-console
-    console.log('in build model');
-    // tslint:disable-next-line:no-console
-    console.log(runs);
     return {
       Name: this.state.analysis.name,
       Description: this.state.analysis.description,
@@ -859,7 +851,10 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     jwtFetch(`${domainRoot}/api/predictors?run_id=${runIds}`)
     .then((data: Predictor[]) => {
       // If there is a statusCode we do not have a list of predictors
-      if ((data as any).statusCode) {
+      if ((data as any).statusCode === undefined) {
+        this.setState({
+          predictorsLoad: false
+        });
         return;
       }
       const selectedPredictors = data.filter(
@@ -934,9 +929,10 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
       this.saveAnalysis({compile: false})();
       this.setState({saveFromUpdate: false});
     }
-    /*
+    if ((prevState.analysis.runIds.length !== this.state.analysis.runIds.length)
+        && this.state.activeTab !== 'overview') {
+      this.loadPredictors();
     }
-      */
   }
 
   render() {
@@ -973,8 +969,6 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
       activeTab = 'review';
       this.postTabChange(activeTab);
     }
-    // tslint:disable-next-line:no-console
-    console.log(this.state);
     return (
       <div className="App">
           <Prompt

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -847,8 +847,6 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
   }
 
   loadPredictors = () => {
-    // tslint:disable-next-line:no-console
-    console.log('loading predictors');
     let analysis = this.state.analysis;
     let runIds = this.state.analysis.runIds;
     jwtFetch(`${domainRoot}/api/predictors?run_id=${runIds}`)
@@ -931,10 +929,6 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
     if (this.state.saveFromUpdate) {
       this.saveAnalysis({compile: false})();
       this.setState({saveFromUpdate: false});
-    }
-    if (prevState.analysis.runIds.length !== this.state.analysis.runIds.length) {
-      // tslint:disable-next-line:no-console
-      console.log(this.state);
     }
     if ((this.state.loadInitialPredictors === true) 
       && (prevState.analysis.runIds.length !== this.state.analysis.runIds.length)) {

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -69,6 +69,7 @@ let initializeStore = (): Store => ({
   activeTab: 'overview',
   predictorsActive: false,
   predictorsLoad: false,
+  loadInitialPredictors: true,
   transformationsActive: false,
   contrastsActive: false,
   hrfActive: false,
@@ -846,6 +847,8 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
   }
 
   loadPredictors = () => {
+    // tslint:disable-next-line:no-console
+    console.log('loading predictors');
     let analysis = this.state.analysis;
     let runIds = this.state.analysis.runIds;
     jwtFetch(`${domainRoot}/api/predictors?run_id=${runIds}`)
@@ -929,9 +932,14 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
       this.saveAnalysis({compile: false})();
       this.setState({saveFromUpdate: false});
     }
-    if ((prevState.analysis.runIds.length !== this.state.analysis.runIds.length)
-        && this.state.activeTab !== 'overview') {
+    if (prevState.analysis.runIds.length !== this.state.analysis.runIds.length) {
+      // tslint:disable-next-line:no-console
+      console.log(this.state);
+    }
+    if ((this.state.loadInitialPredictors === true) 
+      && (prevState.analysis.runIds.length !== this.state.analysis.runIds.length)) {
       this.loadPredictors();
+      this.setState({loadInitialPredictors: false});
     }
   }
 

--- a/neuroscout/frontend/src/Builder.tsx
+++ b/neuroscout/frontend/src/Builder.tsx
@@ -245,6 +245,9 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
           } else if (data.model !== undefined) {
             this.setState({model: data.model!});
           }
+          if (data.status === 'DRAFT' || data.status === 'FAILED') {
+            this.postTabChange('notatab');
+          }
         })
         .catch(displayError);
     }
@@ -835,10 +838,13 @@ export default class AnalysisBuilder extends React.Component<BuilderProps & Rout
 
     if (activeKey === 'overview' || this.state.predictorsLoad === false) {
       return;
+    } else {
+      this.loadPredictors();
     }
+  }
 
-    // does this need to happen every time? We are relying on this function to do initial load of predictors when
-    // loading an analysis not in draft.
+  loadPredictors = () => {
+    const analysis = this.state.analysis;
     jwtFetch(`${domainRoot}/api/predictors?run_id=${analysis.runIds}`)
     .then((data: Predictor[]) => {
       const selectedPredictors = data.filter(

--- a/neuroscout/frontend/src/ContrastEditor.tsx
+++ b/neuroscout/frontend/src/ContrastEditor.tsx
@@ -2,10 +2,10 @@
  ContrastEditor module for adding/editing a contrast (used in the Contrasts tab)
 */
 import * as React from 'react';
-import { Form, Input, InputNumber, Button, Radio, message, Modal, Alert } from 'antd';
+import { Form, Input, InputNumber, Button, Radio, message, Modal } from 'antd';
 import { Analysis, Predictor, Contrast, ContrastTypeEnum } from './coretypes';
 import { PredictorSelector } from './Predictors';
-import { Space } from './HelperComponents';
+import { DisplayErrorsInline, Space } from './HelperComponents';
 
 const FormItem = Form.Item;
 const RadioGroup = Radio.Group;
@@ -131,24 +131,7 @@ export class ContrastEditor extends React.Component<
     const { availablePredictors } = this.props;
     return (
       <div>
-        {this.props.contrastErrors.length > 0 &&
-          <div>
-            <Alert
-              type="error"
-              showIcon={true}
-              closable={true}
-              message={
-                <ul>
-                  {this.props.contrastErrors.map((x, i) =>
-                    <li key={i}>
-                      {x}
-                    </li>
-                  )}
-                </ul>
-              }
-            />
-            <br />
-          </div>}
+        <DisplayErrorsInline errors={this.props.contrastErrors} />
         <Form>
           <FormItem required={true} label={'Name of Contrast:'}>
             <Input
@@ -212,10 +195,6 @@ export class ContrastEditor extends React.Component<
         <Button
           type="primary"
           onClick={this.onSave}
-          disabled={
-            !(this.props.activeContrast.Name && this.props.activeContrast.ConditionList.length > 0
-            && this.props.activeContrast.ConditionList.length === this.props.activeContrast.Weights.length)
-          }
         >
           OK{' '}
         </Button>

--- a/neuroscout/frontend/src/Contrasts.tsx
+++ b/neuroscout/frontend/src/Contrasts.tsx
@@ -174,7 +174,7 @@ export class ContrastsTab extends React.Component<ContrastsTabProps, ContrastsTa
       <div>
         {activeContrastIndex === -1 &&
           <h2>
-            'Add a new contrast:'
+            Add a new contrast:
           </h2>
         }
         <ContrastEditor

--- a/neuroscout/frontend/src/Contrasts.tsx
+++ b/neuroscout/frontend/src/Contrasts.tsx
@@ -5,7 +5,7 @@
  - ContrastDisplay: component to display a single contrast
 */
 import * as React from 'react';
-import { Alert, Table, Input, Button, Row, Col, Form, Select, Checkbox, Icon, List } from 'antd';
+import { Table, Input, Button, Row, Col, Form, Select, Checkbox, Icon, List } from 'antd';
 import {
   DragDropContext,
   Draggable,
@@ -17,7 +17,7 @@ import {
 } from 'react-beautiful-dnd';
 import { Analysis, Predictor, Contrast } from './coretypes';
 import { displayError, moveItem, reorder } from './utils';
-import { Space } from './HelperComponents';
+import { DisplayErrorsInline, Space } from './HelperComponents';
 import { PredictorSelector } from './Predictors';
 import { ContrastEditor, emptyContrast } from './ContrastEditor';
 const Option = Select.Option;
@@ -192,25 +192,7 @@ export class ContrastsTab extends React.Component<ContrastsTabProps, ContrastsTa
     const ViewMode = () => (
       <div>
         <br />
-        {this.props.contrastErrors.length > 0 && mode !== 'add' &&
-          <div>
-            <Alert
-              type="error"
-              showIcon={true}
-              closable={true}
-              message={
-                <ul>
-                  {this.props.contrastErrors.map((x, i) =>
-                    <li key={i}>
-                      {x}
-                    </li>
-                  )}
-                </ul>
-              }
-            />
-            <br />
-          </div>}
-
+        {mode !== 'add' && <DisplayErrorsInline errors={this.props.contrastErrors} />}
         <DragDropContext onDragEnd={this.onDragEnd}>
           <Droppable droppableId="droppable">
             {(provided: DroppableProvided, snapshot: DroppableStateSnapshot) => (

--- a/neuroscout/frontend/src/HelperComponents.tsx
+++ b/neuroscout/frontend/src/HelperComponents.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Col } from 'antd';
+import { Alert, Col } from 'antd';
 
 // Simple space component to seperate buttons, etc.
 // tslint:disable-next-line:jsx-self-close
@@ -11,6 +11,33 @@ export class MainCol extends React.Component<{}, {}> {
       <Col xxl={{span: 16}} xl={{span: 18}} lg={{span: 20}} xs={{span: 24}} className="mainCol">
         {this.props.children}
       </Col>
+    );
+  }
+}
+
+export class DisplayErrorsInline extends React.Component<{errors: string[]}, {}> {
+  render() {
+    return (
+      <>
+        {this.props.errors.length > 0 &&
+          <div>
+            <Alert
+              type="error"
+              showIcon={true}
+              closable={true}
+              message={
+                <ul>
+                  {this.props.errors.map((x, i) =>
+                    <li key={i}>
+                      {x}
+                    </li>
+                  )}
+                </ul>
+              }
+            />
+            <br />
+          </div>}
+      </>
     );
   }
 }

--- a/neuroscout/frontend/src/Transformations.tsx
+++ b/neuroscout/frontend/src/Transformations.tsx
@@ -6,7 +6,6 @@ This module comtains the following components:
 */
 import * as React from 'react';
 import { 
-  Alert,
   Button,
   Checkbox,
   Col,
@@ -38,7 +37,7 @@ import {
   XformRules,
 } from './coretypes';
 import { displayError, moveItem, reorder } from './utils';
-import { Space } from './HelperComponents';
+import { DisplayErrorsInline, Space } from './HelperComponents';
 import { PredictorSelector } from './Predictors';
 import transformDefinitions from './transforms';
 const Option = Select.Option;
@@ -374,24 +373,7 @@ class XformEditor extends React.Component<XformEditorProps, XformEditorState> {
     const availableParameters = name ? Object.keys(xformRules[name]) : undefined;
     return (
       <div>
-        {this.props.xformErrors.length > 0 &&
-          <div>
-            <Alert
-              type="error"
-              showIcon={true}
-              closable={true}
-              message={
-                <ul>
-                  {this.props.xformErrors.map((x, i) =>
-                    <li key={i}>
-                      {x}
-                    </li>
-                  )}
-                </ul>
-              }
-            />
-            <br />
-          </div>}
+        <DisplayErrorsInline errors={this.props.xformErrors} />
 
         <Form layout="horizontal">
           <Row type="flex">

--- a/neuroscout/frontend/src/coretypes.ts
+++ b/neuroscout/frontend/src/coretypes.ts
@@ -153,6 +153,7 @@ export interface Store {
   activeTab: TabName;
   predictorsActive: boolean;
   predictorsLoad: boolean;
+  loadInitialPredictors: boolean;
   transformationsActive: boolean;
   contrastsActive: boolean;
   hrfActive: boolean;


### PR DESCRIPTION
fixes #443, set another flag in the main store for the initial load of predictors. We want predictors to be loaded the first time we see runIDs populated, which is several re-renders deep from the constructor since we wait on the api.

fixes #389 consolidated the code that displays form validation error messages to be consistent across tabs that display them, just transforms and contrasts right now.