### PR TITLE
Fix slow predictor table rendering.

### DIFF
--- a/neuroscout/frontend/src/Predictors.tsx
+++ b/neuroscout/frontend/src/Predictors.tsx
@@ -185,7 +185,7 @@ export class PredictorSelector extends React.Component<
                 locale={{ emptyText: this.state.searchText ? 'No results found' : 'No data'}}
                 columns={columns}
                 rowKey="id"
-                pagination={false}
+                pagination={{defaultPageSize: 200}}
                 scroll={{y: 465}}
                 size="small"
                 dataSource={this.state.filteredPredictors}


### PR DESCRIPTION
First commit enables pagination and sets the page size to 200.