### PR TITLE
Only create Predictors for EFs present in 90% of runs

### DIFF
--- a/neuroscout/config/transformers.json
+++ b/neuroscout/config/transformers.json
@@ -28,7 +28,7 @@
     ["MeanAmplitudeExtractor", {}],
     ["SpectralCentroidExtractor", {}],
     ["VADERSentimentExtractor", {}],
-    ["RMSEExtractor", {"frame_length": 72000, "hop_length": 72000, "center": false}],
+    ["RMSExtractor", {"frame_length": 72000, "hop_length": 72000, "center": false}],
     ["ComplexTextExtractor", {}],
     ["PredefinedDictionaryExtractor", {"variables": ["subtlexusfrequency/Lg10WF"], "missing": "n/a"} ]
   ],


### PR DESCRIPTION
Closes #541 

I decided on a 90% default

That code in general is not the most efficient and a bit hard to debug, but I can't think of a much better way to do it for now.

At least this will speed things up by only processing useful Features (i.e. those in most runs).