### PR TITLE
Fixes for frontend regressions.

### DIFF
--- a/neuroscout/frontend/src/AnalysisList.tsx
+++ b/neuroscout/frontend/src/AnalysisList.tsx
@@ -39,7 +39,7 @@ class AnalysisList extends React.Component<AnalysisListProps> {
         title: 'Name',
         render: (text, record: AppAnalysis) => (
           <Link to={`/builder/${record.id}`}>
-            {record.name}
+            <div className="recordName">{record.name}</div>
           </Link>
         ),
         sorter: (a, b) => a.name.localeCompare(b.name)

--- a/neuroscout/frontend/src/App.css
+++ b/neuroscout/frontend/src/App.css
@@ -108,3 +108,7 @@ pre {
     max-width: 100%;
     max-height: 80vh;
 }
+
+.recordName {
+    word-break: break-all;
+}

--- a/neuroscout/frontend/src/coretypes.ts
+++ b/neuroscout/frontend/src/coretypes.ts
@@ -183,6 +183,7 @@ export interface Store {
   xformErrors: string[];
   contrastErrors: string[];
   fillAnalysis: boolean;
+  analysis404: boolean;
 }
 
 export interface ApiRun {

--- a/neuroscout/frontend/src/utils.ts
+++ b/neuroscout/frontend/src/utils.ts
@@ -58,22 +58,23 @@ export const jwtFetch = (path: string, options?: object) => {
       });
       throw new Error('Please Login Again');
     }
-    if (response.status !== 200) {
-      // displayError(new Error(`HTTP ${response.status} on ${path}`));
+    if (response.status >= 400) {
+      return { statusCode: response.status };
+    } else {
+      return response.json().then(json => {
+        // Always add statusCode to the data object or array returned by response.json()
+        let copy: any;
+        if ('length' in json) {
+          // array
+          copy = [...json];
+          (copy as any).statusCode = response.status;
+        } else {
+          // object
+          copy = { ...json, statusCode: response.status };
+        }
+        return copy;
+      });
     }
-    return response.json().then(json => {
-      // Always add statusCode to the data object or array returned by response.json()
-      let copy: any;
-      if ('length' in json) {
-        // array
-        copy = [...json];
-        (copy as any).statusCode = response.status;
-      } else {
-        // object
-        copy = { ...json, statusCode: response.status };
-      }
-      return copy;
-    });
   });
 };
 


### PR DESCRIPTION
datasets were moved to props of builder out of state, updated update analysis
function accordingly. Fixes #555 

Disable next button on contrast tab if no contrasts present. Never set
flag to generate reports if no contrasts exist. Fixes #537

Have analyses names line break if too long. Fixes #562

Non existent analysis IDs will now redirect to /builder/. Fixes #484

on error codes 400 and above do not attempt to parse response as json, just
return status code so component can figure out what it wants to do.
Fixes #527