### PR TITLE
Add db to celery

### DIFF
--- a/neuroscout/auth.py
+++ b/neuroscout/auth.py
@@ -1,13 +1,17 @@
 """ Auth related functions """
 from datetime import datetime
-from models.auth import user_datastore, User
+from database import db
+from models import User, Role
 from flask_security.utils import verify_password
+from flask_security import SQLAlchemyUserDatastore
 from flask_security.confirmable import generate_confirmation_token
 from flask_security.recoverable import generate_reset_password_token
 from flask import current_app, url_for
 from mail import send_confirm_mail, send_reset_mail
 from google.oauth2 import id_token
 from google.auth.transport import requests
+
+user_datastore = SQLAlchemyUserDatastore(db, User, Role)
 
 
 def generate_confirmation_link(user):

--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -30,7 +30,7 @@ cache.init_app(app)
 from flask_jwt import JWT
 from flask_security import Security
 from flask_security.confirmable import confirm_email_token_status, confirm_user
-from auth import authenticate, load_user, add_auth_to_swagger
+from auth import authenticate, load_user, add_auth_to_swagger, user_datastore
 from models import *
 
 # Setup Flask-Security and JWT

--- a/neuroscout/database.py
+++ b/neuroscout/database.py
@@ -1,4 +1,5 @@
 """ Set up app database """
 from flask_sqlalchemy import SQLAlchemy
+from models.base import Base
 
-db = SQLAlchemy()
+db = SQLAlchemy(model_class=Base)

--- a/neuroscout/manage.py
+++ b/neuroscout/manage.py
@@ -12,7 +12,7 @@ from flask_security.utils import encrypt_password
 
 import populate
 from core import app, db
-from models import user_datastore
+from auth import user_datastore
 
 app.config.from_object(os.environ['APP_SETTINGS'])
 migrate = Migrate(app, db, directory=app.config['MIGRATIONS_DIR'])

--- a/neuroscout/models/__init__.py
+++ b/neuroscout/models/__init__.py
@@ -2,12 +2,11 @@
 
 from .analysis import (Analysis, Report, NeurovaultCollection,
                        analysis_predictor)
-from .auth import User, Role, roles_users, user_datastore
+from .auth import User, Role, roles_users
 from .group import GroupPredictor, GroupPredictorValue
 from .dataset import Dataset
 from .features import ExtractedFeature, ExtractedEvent
 from .predictor import Predictor, PredictorEvent, PredictorRun
-from .result import Result
 from .run import Run, analysis_run
 from .stimulus import Stimulus, RunStimulus
 from .task import Task
@@ -18,7 +17,6 @@ __all__ = [
     'User',
     'Role',
     'roles_users',
-    'user_datastore',
     'Dataset',
     'ExtractedFeature',
     'ExtractedEvent',
@@ -27,7 +25,6 @@ __all__ = [
     'Predictor',
     'PredictorEvent',
     'PredictorRun',
-    'Result',
     'Report',
     'NeurovaultCollection',
     'Run',

--- a/neuroscout/models/analysis.py
+++ b/neuroscout/models/analysis.py
@@ -11,6 +11,7 @@ from .utils import copy_row
 # Association table between analysis and predictor.
 analysis_predictor = Table(
     'analysis_predictor',
+    Base.metadata,
     Column('analysis_id', Integer(), ForeignKey('analysis.id')),
     Column('predictor_id', Integer(), ForeignKey('predictor.id')))
 

--- a/neuroscout/models/analysis.py
+++ b/neuroscout/models/analysis.py
@@ -53,7 +53,6 @@ class Analysis(Base):
     # If cloned, this is the parent analysis:
     parent_id = Column(Text, ForeignKey('analysis.hash_id'))
 
-    results = relationship('Result', backref='analysis')
     predictors = relationship('Predictor', secondary=analysis_predictor,
                               backref='analysis')
     runs = relationship('Run', secondary='analysis_run')

--- a/neuroscout/models/analysis.py
+++ b/neuroscout/models/analysis.py
@@ -5,8 +5,8 @@ from sqlalchemy import (Column, Integer, Table, ForeignKey, Text,
                         Boolean, DateTime, CheckConstraint)
 from sqlalchemy.orm import relationship
 
-from base import Base
-from utils import copy_row
+from .base import Base
+from .utils import copy_row
 
 # Association table between analysis and predictor.
 analysis_predictor = Table(

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -1,40 +1,42 @@
-from database import db
-from flask_security import UserMixin, RoleMixin, SQLAlchemyUserDatastore
+from flask_security import UserMixin, RoleMixin
+
+from sqlalchemy import (Column, Integer, Table, ForeignKey, Text,
+                        Boolean, DateTime, String)
+from sqlalchemy.orm import relationship, backref
+
+from base import Base
 
 # Association table between users and runs.
-roles_users = db.Table(
+roles_users = Table(
     'roles_users',
-    db.Column('user_id', db.Integer(), db.ForeignKey('user.id')),
-    db.Column('role_id', db.Integer(), db.ForeignKey('role.id')))
+    Column('user_id', Integer(), ForeignKey('user.id')),
+    Column('role_id', Integer(), ForeignKey('role.id')))
 
 
-class User(db.Model, UserMixin):
-    """" User model class """
-    id = db.Column(db.Integer, primary_key=True)
-    google_id = db.Column(db.Text)
-    email = db.Column(db.String(100), unique=True)
-    password = db.Column(db.String(255))
-    picture = db.Column(db.Text)
+class User(Base, UserMixin):
+    """" User Base class """
+    id = Column(Integer, primary_key=True)
+    google_id = Column(Text)
+    email = Column(String(100), unique=True)
+    password = Column(String(255))
+    picture = Column(Text)
 
-    name = db.Column(db.String(40))
-    active = db.Column(db.Boolean())  # If set to disabled, cannot access.
-    confirmed_at = db.Column(db.DateTime())
-    roles = db.relationship('Role', secondary=roles_users,
-                            backref=db.backref('users'))
-    last_activity_at = db.Column(db.DateTime())
-    last_activity_ip = db.Column(db.String(255))
+    name = Column(String(40))
+    active = Column(Boolean())  # If set to disabled, cannot access.
+    confirmed_at = Column(DateTime())
+    roles = relationship('Role', secondary=roles_users,
+                         backref=backref('users'))
+    last_activity_at = Column(DateTime())
+    last_activity_ip = Column(String(255))
 
-    analyses = db.relationship('Analysis', backref='user')
+    analyses = relationship('Analysis', backref='user')
 
     def __repr__(self):
-        return '<models.User[email=%s]>' % self.email
+        return '<Bases.User[email=%s]>' % self.email
 
 
-class Role(db.Model, RoleMixin):
+class Role(Base, RoleMixin):
     """ User roles """
-    id = db.Column(db.Integer(), primary_key=True)
-    name = db.Column(db.String(80), unique=True)
-    description = db.Column(db.String(255))
-
-
-user_datastore = SQLAlchemyUserDatastore(db, User, Role)
+    id = Column(Integer(), primary_key=True)
+    name = Column(String(80), unique=True)
+    description = Column(String(255))

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -9,6 +9,7 @@ from .base import Base
 # Association table between users and runs.
 roles_users = Table(
     'roles_users',
+    Base.metadata,
     Column('user_id', Integer(), ForeignKey('user.id')),
     Column('role_id', Integer(), ForeignKey('role.id')))
 

--- a/neuroscout/models/auth.py
+++ b/neuroscout/models/auth.py
@@ -4,7 +4,7 @@ from sqlalchemy import (Column, Integer, Table, ForeignKey, Text,
                         Boolean, DateTime, String)
 from sqlalchemy.orm import relationship, backref
 
-from base import Base
+from .base import Base
 
 # Association table between users and runs.
 roles_users = Table(

--- a/neuroscout/models/base.py
+++ b/neuroscout/models/base.py
@@ -1,0 +1,11 @@
+from sqlalchemy.ext.declarative import declarative_base, declared_attr
+
+
+class CustomBase(object):
+    # Generate __tablename__ automatically
+    @declared_attr
+    def __tablename__(cls):
+        return cls.__name__.lower()
+
+
+Base = declarative_base(cls=CustomBase)

--- a/neuroscout/models/dataset.py
+++ b/neuroscout/models/dataset.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy import (Column, Integer, Text, Boolean)
 from sqlalchemy.orm import relationship
 
-from base import Base
+from .base import Base
 from .stimulus import Stimulus
 
 

--- a/neuroscout/models/dataset.py
+++ b/neuroscout/models/dataset.py
@@ -1,25 +1,28 @@
-from database import db
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy import (Column, Integer, Text, Boolean)
+from sqlalchemy.orm import relationship
+
+from base import Base
 from .stimulus import Stimulus
 
 
-class Dataset(db.Model):
+class Dataset(Base):
     """ A BIDS dataset """
-    id = db.Column(db.Integer, primary_key=True)
-    description = db.Column(JSONB)  # BIDS description
-    summary = db.Column(db.Text)  # Hand crafted summary
-    url = db.Column(db.Text)  # External resource / link
-    active = db.Column(db.Boolean, default=True)
-    name = db.Column(db.Text, unique=True, nullable=False)
-    runs = db.relationship('Run', backref='dataset')
-    predictors = db.relationship('Predictor', backref='dataset',
-                                 lazy='dynamic')
-    tasks = db.relationship('Task', backref='dataset')
-    analyses = db.relationship('Analysis', backref='dataset')
-    dataset_address = db.Column(db.Text)
-    preproc_address = db.Column(db.Text)
-    local_path = db.Column(db.Text)
+    id = Column(Integer, primary_key=True)
+    description = Column(JSONB)  # BIDS description
+    summary = Column(Text)  # Hand crafted summary
+    url = Column(Text)  # External resource / link
+    active = Column(Boolean, default=True)
+    name = Column(Text, unique=True, nullable=False)
+    runs = relationship('Run', backref='dataset')
+    predictors = relationship('Predictor', backref='dataset',
+                              lazy='dynamic')
+    tasks = relationship('Task', backref='dataset')
+    analyses = relationship('Analysis', backref='dataset')
+    dataset_address = Column(Text)
+    preproc_address = Column(Text)
+    local_path = Column(Text)
 
     @hybrid_property
     def mimetypes(self):

--- a/neuroscout/models/features.py
+++ b/neuroscout/models/features.py
@@ -4,7 +4,7 @@ from sqlalchemy import (Column, Integer, ForeignKey, Text,
                         Boolean, DateTime, String, Float)
 from sqlalchemy.orm import relationship
 
-from base import Base
+from .base import Base
 
 
 class ExtractedFeature(Base):

--- a/neuroscout/models/features.py
+++ b/neuroscout/models/features.py
@@ -1,44 +1,48 @@
-from database import db
 import datetime
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import (Column, Integer, ForeignKey, Text,
+                        Boolean, DateTime, String, Float)
+from sqlalchemy.orm import relationship
+
+from base import Base
 
 
-class ExtractedFeature(db.Model):
+class ExtractedFeature(Base):
     """ Events extracted from a Stimulus using an Extractor"""
-    id = db.Column(db.Integer, primary_key=True)
+    id = Column(Integer, primary_key=True)
     # Hash of next three variables
-    sha1_hash = db.Column(db.Text, nullable=False)
-    extractor_name = db.Column(db.String)
-    extractor_parameters = db.Column(JSONB)
-    feature_name = db.Column(db.String)
-    original_name = db.Column(db.String)  # Original feature_name
-    description = db.Column(db.String)
-    active = db.Column(db.Boolean)
-    modality = db.Column(db.String)
-    transformed = db.Column(db.Boolean, default=False)
+    sha1_hash = Column(Text, nullable=False)
+    extractor_name = Column(String)
+    extractor_parameters = Column(JSONB)
+    feature_name = Column(String)
+    original_name = Column(String)  # Original feature_name
+    description = Column(String)
+    active = Column(Boolean)
+    modality = Column(String)
+    transformed = Column(Boolean, default=False)
 
-    created_at = db.Column(db.DateTime, default=datetime.datetime.utcnow)
-    extractor_version = db.Column(db.Float, default=0.1)
+    created_at = Column(DateTime, default=datetime.datetime.utcnow)
+    extractor_version = Column(Float, default=0.1)
 
-    extracted_events = db.relationship(
+    extracted_events = relationship(
         'ExtractedEvent', backref='extracted_feature')
-    generated_predictors = db.relationship(
+    generated_predictors = relationship(
         'Predictor', backref='extracted_feature')
 
     def __repr__(self):
         return '<models.ExtractedFeature[feature_name=%s]>' % self.feature_name
 
 
-class ExtractedEvent(db.Model):
+class ExtractedEvent(Base):
     """ Events extracted from a Stimuli"""
-    id = db.Column(db.Integer, primary_key=True)
-    onset = db.Column(db.Float)
-    duration = db.Column(db.Float)
-    value = db.Column(db.String, nullable=False)
-    history = db.Column(db.String)
-    object_id = db.Column(db.Integer)
+    id = Column(Integer, primary_key=True)
+    onset = Column(Float)
+    duration = Column(Float)
+    value = Column(String, nullable=False)
+    history = Column(String)
+    object_id = Column(Integer)
 
-    stimulus_id = db.Column(
-        db.Integer, db.ForeignKey('stimulus.id'), nullable=False)
-    ef_id = db.Column(
-        db.Integer, db.ForeignKey(ExtractedFeature.id), nullable=False)
+    stimulus_id = Column(
+        Integer, ForeignKey('stimulus.id'), nullable=False)
+    ef_id = Column(
+        Integer, ForeignKey(ExtractedFeature.id), nullable=False)

--- a/neuroscout/models/group.py
+++ b/neuroscout/models/group.py
@@ -1,27 +1,30 @@
-from database import db
+from sqlalchemy import (Column, Integer, ForeignKey, Text, String)
+from sqlalchemy.orm import relationship
+
+from base import Base
 
 
-class GroupPredictor(db.Model):
+class GroupPredictor(Base):
     """ Group-level predictors, e.g. across subjects, sessions, etc... """
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.Text, nullable=False)
-    description = db.Column(db.Text)  # Where to get this from?
-    level = db.Column(db.String, nullable=False)  # Session? Subject?
+    id = Column(Integer, primary_key=True)
+    name = Column(Text, nullable=False)
+    description = Column(Text)  # Where to get this from?
+    level = Column(String, nullable=False)  # Session? Subject?
 
-    dataset_id = db.Column(
-        db.Integer, db.ForeignKey('dataset.id'), nullable=False)
+    dataset_id = Column(
+        Integer, ForeignKey('dataset.id'), nullable=False)
 
-    values = db.relationship('GroupPredictorValue', backref='group_predictor')
+    values = relationship('GroupPredictorValue', backref='group_predictor')
 
     def __repr__(self):
         return '<models.GroupPredictor[name=%s]>' % self.name
 
 
-class GroupPredictorValue(db.Model):
+class GroupPredictorValue(Base):
     """ Contains values of GroupPredictor for every Run.
         Also an association table between these two tables. """
-    gp_id = db.Column(db.Integer, db.ForeignKey('group_predictor.id'),
-                      primary_key=True)
-    run_id = db.Column(db.Integer, db.ForeignKey('run.id'), primary_key=True)
-    level_id = db.Column(db.String, primary_key=True)
-    value = db.Column(db.String, nullable=False)
+    gp_id = Column(Integer, ForeignKey('group_predictor.id'),
+                   primary_key=True)
+    run_id = Column(Integer, ForeignKey('run.id'), primary_key=True)
+    level_id = Column(String, primary_key=True)
+    value = Column(String, nullable=False)

--- a/neuroscout/models/group.py
+++ b/neuroscout/models/group.py
@@ -1,7 +1,7 @@
 from sqlalchemy import (Column, Integer, ForeignKey, Text, String)
 from sqlalchemy.orm import relationship
 
-from base import Base
+from .base import Base
 
 
 class GroupPredictor(Base):

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -1,54 +1,59 @@
-from database import db
+from sqlalchemy import (Column, Integer, ForeignKey, Text, String,
+                        Boolean, Float, UniqueConstraint, Index)
+from sqlalchemy.orm import relationship
 
-class Predictor(db.Model):
+from base import Base
+
+
+class Predictor(Base):
     """ Instantiation of a predictor in a dataset.
     A collection of PredictorEvents. """
 
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.Text, nullable=False)
-    original_name = db.Column(db.Text)
-    source = db.Column(db.Text)
-    description = db.Column(db.Text)
+    id = Column(Integer, primary_key=True)
+    name = Column(Text, nullable=False)
+    original_name = Column(Text)
+    source = Column(Text)
+    description = Column(Text)
 
-    dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'),
-                           nullable=False)
-    ef_id = db.Column(db.Integer, db.ForeignKey('extracted_feature.id'))
+    dataset_id = Column(Integer, ForeignKey('dataset.id'),
+                        nullable=False)
+    ef_id = Column(Integer, ForeignKey('extracted_feature.id'))
 
-    predictor_events = db.relationship('PredictorEvent', backref='predictor')
+    predictor_events = relationship('PredictorEvent', backref='predictor')
 
-    predictor_run = db.relationship('PredictorRun')
-    active = db.Column(db.Boolean, default=True)  # Actively display or not
+    predictor_run = relationship('PredictorRun')
+    active = Column(Boolean, default=True)  # Actively display or not
 
     def __repr__(self):
         return '<models.Predictor[name=%s]>' % self.name
 
 
-class PredictorEvent(db.Model):
+class PredictorEvent(Base):
     """ An event within a Predictor. Onset is relative to run. """
     __table_args__ = (
-        db.UniqueConstraint('onset', 'run_id', 'predictor_id', 'object_id'),
-        db.Index('ix_predictor_id_run_id', "predictor_id", "run_id")
+        UniqueConstraint('onset', 'run_id', 'predictor_id', 'object_id'),
+        Index('ix_predictor_id_run_id', "predictor_id", "run_id")
     )
-    id = db.Column(db.Integer, primary_key=True)
+    id = Column(Integer, primary_key=True)
 
-    onset = db.Column(db.Float, nullable=False)
-    duration = db.Column(db.Float)
-    value = db.Column(db.String, nullable=False)
-    object_id = db.Column(db.Integer)
+    onset = Column(Float, nullable=False)
+    duration = Column(Float)
+    value = Column(String, nullable=False)
+    object_id = Column(Integer)
 
-    run_id = db.Column(db.Integer, db.ForeignKey('run.id'), nullable=False,
-                       index=True)
-    predictor_id = db.Column(db.Integer, db.ForeignKey('predictor.id'),
-                             nullable=False, index=True)
-    stimulus_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))
+    run_id = Column(Integer, ForeignKey('run.id'), nullable=False,
+                    index=True)
+    predictor_id = Column(Integer, ForeignKey('predictor.id'),
+                          nullable=False, index=True)
+    stimulus_id = Column(Integer, ForeignKey('stimulus.id'))
 
     def __repr__(self):
         return '<models.PredictorEvent[run_id={} predictor={}]>'.format(
             self.run_id, self.predictor.name)
 
 
-class PredictorRun(db.Model):
+class PredictorRun(Base):
     """ Predictor run association cache table """
-    run_id = db.Column(db.Integer, db.ForeignKey('run.id'), primary_key=True)
-    predictor_id = db.Column(db.Integer, db.ForeignKey('predictor.id'),
-                             primary_key=True)
+    run_id = Column(Integer, ForeignKey('run.id'), primary_key=True)
+    predictor_id = Column(Integer, ForeignKey('predictor.id'),
+                          primary_key=True)

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -2,7 +2,7 @@ from sqlalchemy import (Column, Integer, ForeignKey, Text, String,
                         Boolean, Float, UniqueConstraint, Index)
 from sqlalchemy.orm import relationship
 
-from base import Base
+from .base import Base
 
 
 class Predictor(Base):

--- a/neuroscout/models/result.py
+++ b/neuroscout/models/result.py
@@ -1,7 +1,0 @@
-from database import db
-
-class Result(db.Model):
-	"""" Some representation of the result of an analysis. TBD """
-	id = db.Column(db.Integer, primary_key=True)
-
-	analysis_id = db.Column(db.Integer, db.ForeignKey('analysis.id'))

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -2,7 +2,7 @@ from sqlalchemy import (Column, Integer, Table, ForeignKey, Text, Float,
                         UniqueConstraint)
 from sqlalchemy.orm import relationship
 
-from base import Base
+from .base import Base
 
 
 # Association table between analysis and run.

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -1,41 +1,46 @@
-from database import db
+from sqlalchemy import (Column, Integer, Table, ForeignKey, Text, Float,
+                        UniqueConstraint)
+from sqlalchemy.orm import relationship
+
+from base import Base
+
 
 # Association table between analysis and run.
-analysis_run = db.Table(
+analysis_run = Table(
     'analysis_run',
-    db.Column('analysis_id', db.Integer(), db.ForeignKey('analysis.id')),
-    db.Column('run_id', db.Integer(), db.ForeignKey('run.id')))
+    Column('analysis_id', Integer(), ForeignKey('analysis.id')),
+    Column('run_id', Integer(), ForeignKey('run.id')))
 
 
-class Run(db.Model):
+class Run(Base):
     """ A single scan run. The basic unit of fMRI analysis. """
     __table_args__ = (
-        db.UniqueConstraint(
+        UniqueConstraint(
             'session', 'subject', 'number', 'task_id', 'dataset_id'),
     )
-    id = db.Column(db.Integer, primary_key=True)
-    session = db.Column(db.Text)
-    acquisition = db.Column(db.Text)
+    id = Column(Integer, primary_key=True)
+    session = Column(Text)
+    acquisition = Column(Text)
 
-    subject = db.Column(db.Text)
-    number = db.Column(db.Integer)
+    subject = Column(Text)
+    number = Column(Integer)
 
-    duration = db.Column(db.Float)
+    duration = Column(Float)
 
-    task_id = db.Column(db.Integer, db.ForeignKey('task.id'),
-                        nullable=False)
-    dataset_id = db.Column(
-        db.Integer, db.ForeignKey('dataset.id'), nullable=False)
+    task_id = Column(Integer, ForeignKey('task.id'),
+                     nullable=False)
+    dataset_id = Column(
+        Integer, ForeignKey('dataset.id'), nullable=False)
 
-    prs = db.relationship('PredictorRun',
-                          cascade='delete')
-    gpv = db.relationship('GroupPredictorValue',
-                          cascade='delete')
-    predictor_events = db.relationship(
+    prs = relationship('PredictorRun',
+                       cascade='delete')
+    gpv = relationship('GroupPredictorValue',
+                       cascade='delete')
+    predictor_events = relationship(
         'PredictorEvent', backref='run',
         cascade='delete',
         lazy='dynamic')
-    analyses = db.relationship(
+    analyses = relationship(
         'Analysis', secondary='analysis_run')
 
     def __repr__(self):

--- a/neuroscout/models/run.py
+++ b/neuroscout/models/run.py
@@ -8,6 +8,7 @@ from .base import Base
 # Association table between analysis and run.
 analysis_run = Table(
     'analysis_run',
+    Base.metadata,
     Column('analysis_id', Integer(), ForeignKey('analysis.id')),
     Column('run_id', Integer(), ForeignKey('run.id')))
 

--- a/neuroscout/models/stimulus.py
+++ b/neuroscout/models/stimulus.py
@@ -1,51 +1,55 @@
-from database import db
+from sqlalchemy import (Column, Integer, ForeignKey, Text, String, Float,
+                        Boolean, CheckConstraint, UniqueConstraint)
+from sqlalchemy.orm import relationship
+
+from base import Base
 
 
-class Stimulus(db.Model):
+class Stimulus(Base):
     """ A unique stimulus. A stimulus may occur at different points in time,
         and perhaps even across different datasets. """
     __table_args__ = (
-        db.UniqueConstraint('sha1_hash', 'dataset_id', 'converter_name',
-                            'parent_id'),
+        UniqueConstraint('sha1_hash', 'dataset_id', 'converter_name',
+                         'parent_id'),
     )
 
     __table_args__ = (
-          db.CheckConstraint('NOT(path IS NULL AND content IS NULL)'),
+          CheckConstraint('NOT(path IS NULL AND content IS NULL)'),
     )
 
-    id = db.Column(db.Integer, primary_key=True)
-    sha1_hash = db.Column(db.Text, nullable=False)
-    mimetype = db.Column(db.Text, nullable=False)
+    id = Column(Integer, primary_key=True)
+    sha1_hash = Column(Text, nullable=False)
+    mimetype = Column(Text, nullable=False)
 
-    path = db.Column(db.Text)
-    content = db.Column(db.Text)
+    path = Column(Text)
+    content = Column(Text)
 
-    dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'),
-                           nullable=False)
+    dataset_id = Column(Integer, ForeignKey('dataset.id'),
+                        nullable=False)
 
-    active = db.Column(db.Boolean, nullable=False, default=True)
+    active = Column(Boolean, nullable=False, default=True)
 
     # For converted stimuli
-    parent_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))
-    converter_name = db.Column(db.String)
-    converter_parameters = db.Column(db.Text)
+    parent_id = Column(Integer, ForeignKey('stimulus.id'))
+    converter_name = Column(String)
+    converter_parameters = Column(Text)
 
-    extracted_events = db.relationship('ExtractedEvent')
-    runs = db.relationship('Run', secondary='run_stimulus')
-    run_stimuli = db.relationship('RunStimulus', backref='stimulus', 
-                                  lazy='dynamic')
+    extracted_events = relationship('ExtractedEvent')
+    runs = relationship('Run', secondary='run_stimulus')
+    run_stimuli = relationship('RunStimulus', backref='stimulus',
+                               lazy='dynamic')
 
     def __repr__(self):
         return '<models.Stimulus[hash={}]>'.format(self.sha1_hash)
 
 
-class RunStimulus(db.Model):
+class RunStimulus(Base):
     """ Run Stimulus association table """
     __table_args__ = (
-        db.UniqueConstraint('stimulus_id', 'run_id', 'onset'),
+        UniqueConstraint('stimulus_id', 'run_id', 'onset'),
     )
-    id = db.Column(db.Integer, primary_key=True)
-    stimulus_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))
-    run_id = db.Column(db.Integer, db.ForeignKey('run.id'))
-    onset = db.Column(db.Float)
-    duration = db.Column(db.Float)
+    id = Column(Integer, primary_key=True)
+    stimulus_id = Column(Integer, ForeignKey('stimulus.id'))
+    run_id = Column(Integer, ForeignKey('run.id'))
+    onset = Column(Float)
+    duration = Column(Float)

--- a/neuroscout/models/stimulus.py
+++ b/neuroscout/models/stimulus.py
@@ -2,7 +2,7 @@ from sqlalchemy import (Column, Integer, ForeignKey, Text, String, Float,
                         Boolean, CheckConstraint, UniqueConstraint)
 from sqlalchemy.orm import relationship
 
-from base import Base
+from .base import Base
 
 
 class Stimulus(Base):

--- a/neuroscout/models/task.py
+++ b/neuroscout/models/task.py
@@ -1,27 +1,32 @@
-from database import db
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy import (Column, Integer, ForeignKey, Text, Float,
+                        UniqueConstraint)
+from sqlalchemy.orm import relationship
 
-class Task(db.Model):
+from base import Base
+
+
+class Task(Base):
     """ A task in a dataset. Usually associated with various runs. """
     __table_args__ = (
-        db.UniqueConstraint('dataset_id', 'name'),
+        UniqueConstraint('dataset_id', 'name'),
     )
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.Text, nullable=False) # Default: base path
-    description = db.Column(JSONB) # BIDS task description
+    id = Column(Integer, primary_key=True)
+    name = Column(Text, nullable=False)  # Default: base path
+    description = Column(JSONB)  # BIDS task description
 
-    dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'),
-                           nullable=False)
+    dataset_id = Column(Integer, ForeignKey('dataset.id'),
+                        nullable=False)
 
-    runs = db.relationship('Run', backref='task', cascade="delete")
-    TR = db.Column(db.Float)
-    summary = db.Column(db.Text) # Summary annotation
+    runs = relationship('Run', backref='task', cascade="delete")
+    TR = Column(Float)
+    summary = Column(Text)  # Summary annotation
 
     @hybrid_property
     def num_runs(self):
-    	""" List of mimetypes of stimuli in dataset """
-    	return len(self.runs)
+        """ List of mimetypes of stimuli in dataset """
+        return len(self.runs)
 
     def __repr__(self):
         return '<models.Task[name={}]>'.format(self.name)

--- a/neuroscout/models/task.py
+++ b/neuroscout/models/task.py
@@ -4,7 +4,7 @@ from sqlalchemy import (Column, Integer, ForeignKey, Text, Float,
                         UniqueConstraint)
 from sqlalchemy.orm import relationship
 
-from base import Base
+from .base import Base
 
 
 class Task(Base):

--- a/neuroscout/models/utils.py
+++ b/neuroscout/models/utils.py
@@ -1,0 +1,15 @@
+""" Utilities that don't touch flask """
+
+
+def copy_row(model, row, ignored_columns=[], ignored_relationships=[]):
+    copy = model()
+
+    for col in row.__table__.columns:
+        if col.name not in ignored_columns:
+            copy.__setattr__(col.name, getattr(row, col.name))
+
+    # Copy relationships:
+    for r in row.__mapper__.relationships:
+        if r.key not in ignored_relationships:
+            copy.__setattr__(r.key, getattr(row, r.key))
+    return copy

--- a/neuroscout/tests/conftest.py
+++ b/neuroscout/tests/conftest.py
@@ -8,7 +8,7 @@ import datetime
 import sqlalchemy as sa
 import pandas as pd
 from flask import current_app
-from models import (Analysis, Result, Predictor,
+from models import (Analysis, Predictor,
                     PredictorEvent, User, Role, Dataset)
 import populate
 

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlalchemy import func
 from models import (
-    Analysis, User, Dataset, Predictor, Stimulus, Run, RunStimulus, Result,
+    Analysis, User, Dataset, Predictor, Stimulus, Run, RunStimulus,
     ExtractedFeature, PredictorEvent, GroupPredictor, Task)
 
 from numpy import isclose
@@ -180,10 +180,6 @@ def test_analysis(session, add_analysis, add_predictor):
 
     assert clone.id > first_analysis.id
     assert clone.name == first_analysis.name
-
-
-def test_result(add_result):
-    assert Result.query.count() == 1
 
 
 def test_external_text(get_data_path, add_task):

--- a/neuroscout/utils/__init__.py
+++ b/neuroscout/utils/__init__.py
@@ -1,12 +1,11 @@
 """ Neuroscout utilities """
 
 from .core import route_factory, listify
-from .db import copy_row, put_record, get_or_create
+from .db import put_record, get_or_create
 
 __all__ = [
     'route_factory',
     'listify',
-    'copy_row',
     'put_record',
     'get_or_create'
 ]

--- a/neuroscout/utils/db.py
+++ b/neuroscout/utils/db.py
@@ -4,19 +4,11 @@
 from flask import abort, current_app
 from sqlalchemy.exc import SQLAlchemyError
 from database import db
+from hashids import Hashids
 
-def copy_row(model, row, ignored_columns=[], ignored_relationships=[]):
-    copy = model()
+from sqlalchemy.event import listens_for
+from models import Analysis
 
-    for col in row.__table__.columns:
-        if col.name not in ignored_columns:
-            copy.__setattr__(col.name, getattr(row, col.name))
-
-    # Copy relationships:
-    for r in row.__mapper__.relationships:
-        if r.key not in ignored_relationships:
-            copy.__setattr__(r.key, getattr(row, r.key))
-    return copy
 
 def put_record(updated_values, instance, commit=True):
     try:
@@ -30,6 +22,7 @@ def put_record(updated_values, instance, commit=True):
         current_app.logger.error(e)
         db.session.rollback()
         abort(400, "Error updating field")
+
 
 def get_or_create(model, commit=True, **kwargs):
     """ Checks to see if instance of model is in db.
@@ -53,3 +46,15 @@ def get_or_create(model, commit=True, **kwargs):
             db.session.commit()
 
         return instance, True
+
+@listens_for(Analysis, "after_insert")
+def update_hash(mapper, connection, target):
+    """ Update hash of Analysis model """
+    analysis_table = mapper.local_table
+    connection.execute(
+         analysis_table.update().
+         values(
+             hash_id=Hashids(
+                 current_app.config['HASH_SALT'], min_length=5).
+             encode(target.id)).where(analysis_table.c.id == target.id)
+    )


### PR DESCRIPTION
This is a refactor of the models in neuroscout so that they use vanilla `SQLAlchemy`. This was they are importable from other non-Flask places, such as Celery.

Currently, relationships are problematic, they me be a difference is now ForeignKeys are defined between flask-sqlalchemy and vanilla.

```
sqlalchemy.exc.NoForeignKeysError: Could not determine join condition between parent/child tables on relationship ExtractedFeature.generated_predictors - there are no foreign keys linking these tables.  Ensure that referencing columns are associated with a ForeignKey or ForeignKeyConstraint, or specify a 'primaryjoin' expression.
```