### PR TITLE
Fix tarball upload

### DIFF
--- a/celery_worker/tasks.py
+++ b/celery_worker/tasks.py
@@ -202,7 +202,7 @@ def upload(img_tarball, hash_id, upload_id, timestamp=None, n_subjects=None):
     try:
         # Untar:
         tmp_dir = Path(mkdtemp())
-        with tarfile.open(img_tarball) as tf:
+        with tarfile.open(img_tarball, mode="r:gz") as tf:
             tf.extractall(tmp_dir)
     except Exception as e:
         update_record(

--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -122,7 +122,7 @@ class FileField(wa.fields.Raw):
 @doc(tags=['analysis'])
 class AnalysisUploadResource(MethodResource):
     @doc(summary='Upload fitlins analysis tarball.',
-         consumes=['multipart/form-dat', 'application/x-www-form-urlencoded'])
+         consumes=['multipart/form-data', 'application/x-www-form-urlencoded'])
     @marshal_with(NeurovaultCollectionSchema)
     @use_kwargs({
         "tarball": FileField(required=True),


### PR DESCRIPTION
Often, uploads were failing because of compressed file corruption error.

This might be because due to incorrect read mode, and context headers. 