### PR TITLE
[WIP] Link to neurovault uploads.

### DIFF
--- a/neuroscout/frontend/src/Status.tsx
+++ b/neuroscout/frontend/src/Status.tsx
@@ -294,12 +294,14 @@ export class StatusTab extends React.Component<submitProps, statusTabState> {
           })
         }
         {(this.state.nvUploads.failed) &&
+          <p>
           <Alert
             message="Last failed upload:"
             description={`Failed at ${this.state.nvUploads.failed.uploaded_at}
               <br/>${this.state.nvUploads.failed.traceback}`}
             type="error"
           />
+          </p>
         }
         </div>
       }

--- a/neuroscout/frontend/src/Status.tsx
+++ b/neuroscout/frontend/src/Status.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Button, Card, Checkbox, Modal, Tag, Icon, Tooltip, Switch } from 'antd';
+import { Alert, Button, Card, Checkbox, Modal, Tag, Icon, Tooltip, Switch } from 'antd';
 import { config } from './config';
 import { displayError, jwtFetch, alphaSort, timeout } from './utils';
 import { ApiAnalysis, Analysis } from './coretypes';
+import { api } from './api';
 
 const domainRoot = config.server_url;
 
@@ -158,13 +159,24 @@ export class Submit extends React.Component<submitProps, {tosAgree: boolean, val
   }
 }
 
-export class StatusTab extends React.Component<submitProps, {compileTraceback: string}> {
+type statusTabState = {
+  compileTraceback: string,
+  nvUploads?: any
+};
+export class StatusTab extends React.Component<submitProps, statusTabState> {
   constructor(props) {
     super(props);
     this.state = {
       compileTraceback: '',
     };
-    this.getTraceback(this.props.analysisId);
+    if ((this.props.analysisId !== undefined)) {
+      this.getTraceback(this.props.analysisId);
+      api.getNVUploads(this.props.analysisId).then(nvUploads => {
+        if (nvUploads !== null) {
+          this.setState({nvUploads: nvUploads});
+        }
+     });
+    }
   }
 
   getTraceback(id) {
@@ -183,9 +195,22 @@ export class StatusTab extends React.Component<submitProps, {compileTraceback: s
     if ((nextProps.status !== this.props.status) && (nextProps.status === 'FAILED')) {
       this.getTraceback(nextProps.analysisId);
     }
-    if ((nextProps.analysisId !== this.props.analysisId)) {
+    if ((nextProps.analysisId !== this.props.analysisId && nextProps.analysisId !== undefined)) {
       this.getTraceback(nextProps.analysisId);
+      api.getNVUploads(nextProps.analysisId).then(nvUploads => {
+        if (nvUploads !== null) {
+          this.setState({nvUploads: nvUploads});
+        }
+      });
     }
+  }
+
+  nvLink(collection_id: any) {
+    return (
+      <a href="https://neurovault.org/collections/{collection_id}/">
+        https://neurovault.org/collections/{collection_id}/
+      </a>
+    );
   }
 
   render() {
@@ -245,6 +270,36 @@ export class StatusTab extends React.Component<submitProps, {compileTraceback: s
         <div>
           <h3>Analysis Pending Generation</h3>
           <p>Analysis generation may take some time. This page will update when complete.</p>
+        </div>
+      }
+      {(this.state.nvUploads) &&
+        <div>
+        <h3>NeuroVault Uploads</h3>
+        {(this.state.nvUploads.pending) &&
+          <Alert
+            message="Latest Attempted Upload:"
+            description={`${this.state.nvUploads.pending.uploaded_at}`}
+            type="warning"
+          />
+        }
+        {(this.state.nvUploads.ok) &&
+          this.state.nvUploads.ok.map((x, i) => {
+            return (<Alert
+              key={x.collection_id}
+              message={this.nvLink(x.collection_id)}
+              description={`Uploaded at: ${x.uploaded_at}`}
+              type="success"
+            />);
+          })
+        }
+        {(this.state.nvUploads.failed) &&
+          <Alert
+            message="Last failed upload:"
+            description={`Failed at ${this.state.nvUploads.failed.uploaded_at}
+              <br/>${this.state.nvUploads.failed.traceback}`}
+            type="error"
+          />
+        }
         </div>
       }
       {this.props.children}

--- a/neuroscout/frontend/src/Status.tsx
+++ b/neuroscout/frontend/src/Status.tsx
@@ -206,8 +206,9 @@ export class StatusTab extends React.Component<submitProps, statusTabState> {
   }
 
   nvLink(collection_id: any) {
+    let url = `https://neurovault.org/collections/${collection_id}`;
     return (
-      <a href="https://neurovault.org/collections/{collection_id}/">
+      <a href={url}>
         https://neurovault.org/collections/{collection_id}/
       </a>
     );

--- a/neuroscout/frontend/src/api.ts
+++ b/neuroscout/frontend/src/api.ts
@@ -49,6 +49,9 @@ export const api = {
         'pending': null as any,
         'ok': [] as any[]
       };
+      if (data.length === 0) {
+        return null;
+      }
       let failed = data.filter(x => x.status  === 'FAILED');
       if (failed.length > 0) {
         failed.sort((a, b) => b.uploaded_at.localeCompare(a.uploaded_at));

--- a/neuroscout/frontend/src/api.ts
+++ b/neuroscout/frontend/src/api.ts
@@ -52,6 +52,7 @@ export const api = {
       if (data.length === 0) {
         return null;
       }
+      data.map(x => x.uploaded_at = x.uploaded_at.replace('T', ' '));
       let failed = data.filter(x => x.status  === 'FAILED');
       if (failed.length > 0) {
         failed.sort((a, b) => b.uploaded_at.localeCompare(a.uploaded_at));

--- a/neuroscout/frontend/src/api.ts
+++ b/neuroscout/frontend/src/api.ts
@@ -40,5 +40,33 @@ export const api = {
       displayError(error);
       return null;
     });
+  },
+  getNVUploads: (analysisId: (string)): Promise<(any | null)> => {
+    return jwtFetch(domainRoot + `/api/analyses/${analysisId}/upload`)
+    .then(data => {
+      let uploads = { 
+        'last_failed': null as any,
+        'pending': null as any,
+        'ok': [] as any[]
+      };
+      let failed = data.filter(x => x.status  === 'FAILED');
+      if (failed.length > 0) {
+        failed.sort((a, b) => b.uploaded_at.localeCompare(a.uploaded_at));
+        uploads.last_failed = failed[0];
+      }
+      uploads.ok = data.filter(x => x.status === 'OK');
+      if (uploads.ok.length === 0) {
+       let pending = data.filter(x => x.status  === 'PENDING');
+       if (pending.length > 0) {
+         failed.sort((a, b) => b.uploaded_at.localeCompare(a.uploaded_at));
+         uploads.pending = pending[0];
+       }
+      }
+      return uploads;
+    })
+    .catch((error) => {
+      displayError(error);
+      return null;
+    });
   }
 };


### PR DESCRIPTION
Currently will only display latest failed attempt with traceback, and will only show latest pending attempt with traceback if there are no successes. All success shown if available. Not sure how to word the failed and pending titles.

API endpoint currently only hit on initial analysis load and when the analysisId changes.