### PR TITLE
filter out contrasts whose source is 'fmriprep' in autocontrast creation

### DIFF
--- a/neuroscout/frontend/src/Contrasts.tsx
+++ b/neuroscout/frontend/src/Contrasts.tsx
@@ -143,6 +143,9 @@ export class ContrastsTab extends React.Component<ContrastsTabProps, ContrastsTa
     let predictors = this.props.predictors;
     let newContrasts = [...this.props.contrasts];
     predictors.map((x) => {
+      if (x.source === 'fmriprep') {
+        return;
+      }
       let newContrast = emptyContrast();
       newContrast.Name = `${x.name}`;
       newContrast.ConditionList = predictors.map(y => y.name);


### PR DESCRIPTION
fixes #506