### PR TITLE
Add optional description to predictor upload

### DIFF
--- a/celery_worker/tasks.py
+++ b/celery_worker/tasks.py
@@ -3,6 +3,7 @@ from app import flask_app, celery_app, cache
 import neuroscout.tasks.report as report
 import neuroscout.tasks.upload as upload
 
+
 @celery_app.task(name='workflow.compile')
 def compile(hash_id, run_ids, build):
     return report.compile(flask_app, hash_id, run_ids, build)
@@ -21,6 +22,7 @@ def upload_neurovault(img_tarball, hash_id, upload_id, timestamp, n_subjects):
 
 
 @celery_app.task(name='collection.upload')
-def upload_collection(filenames, runs, dataset_id, collection_id):
-    return upload.upload_collection(flask_app, filenames, runs,
-                                    dataset_id, collection_id, cache)
+def upload_collection(
+        filenames, runs, dataset_id, collection_id, descriptions):
+    return upload.upload_collection(flask_app, filenames, runs, dataset_id,
+                                    collection_id, descriptions, cache)

--- a/neuroscout/frontend/src/analysis_builder/Status.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Status.tsx
@@ -207,9 +207,8 @@ export class StatusTab extends React.Component<submitProps, statusTabState> {
         <div>
           <h3>Analysis Passed</h3>
           <p>
-            {this.props.userOwns && 'Congratulations!'} The analysis is finished compiling and is ready to be executed.
-            Once you have installed Docker you may run the analysis with the following command,
-            replacing '/local/directory' with a directory on your computer:
+            {this.props.userOwns && 'Congratulations!'} Congratulations, your analysis has been compiled!
+            Run the analysis with this this command, replacing '/local/outputdirectory' with a local directory:
           </p>
           <pre>
             <code>
@@ -221,6 +220,12 @@ export class StatusTab extends React.Component<submitProps, statusTabState> {
             See the <a href="https://github.com/neuroscout/neuroscout-cli">neuroscout-cli documentation </a>
              for more information on how to install and run analyses.
           </p>
+          <Card size="small" title="System Requirements" style={{ width: 400 }}>
+            <p>OS: Windows/Linux/Mac OS with <a href="https://docs.docker.com/install/">Docker</a></p>
+            <p>RAM: 8GB+ RAM</p>
+            <p>Disk space: 4GB + ~1 GB/subject</p>
+          </Card>
+          <br/>
         </div>
       }
       {(this.props.status === 'FAILED') &&

--- a/neuroscout/frontend/src/analysis_builder/Status.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Status.tsx
@@ -208,7 +208,9 @@ export class StatusTab extends React.Component<submitProps, statusTabState> {
           <h3>Analysis Passed</h3>
           <p>
             {this.props.userOwns && 'Congratulations!'} Congratulations, your analysis has been compiled!
-            Run the analysis with this this command, replacing '/local/outputdirectory' with a local directory:
+            Run the analysis with this this command, replacing '/local/outputdirectory' with a local directory.
+            See the <a href="https://github.com/neuroscout/neuroscout-cli">neuroscout-cli documentation </a>
+             for more information.
           </p>
           <pre>
             <code>
@@ -216,10 +218,6 @@ export class StatusTab extends React.Component<submitProps, statusTabState> {
               neuroscout/neuroscout-cli run /out {this.props.analysisId}
             </code>
           </pre>
-          <p>
-            See the <a href="https://github.com/neuroscout/neuroscout-cli">neuroscout-cli documentation </a>
-             for more information on how to install and run analyses.
-          </p>
           <Card size="small" title="System Requirements" style={{ width: 400 }}>
             <p>OS: Windows/Linux/Mac OS with <a href="https://docs.docker.com/install/">Docker</a></p>
             <p>RAM: 8GB+ RAM</p>

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -129,11 +129,15 @@ class PredictorCollectionResource(MethodResource):
             Required columns: onset, duration, any number of columns\
             with values for new Predictors."),
         "runs": wa.fields.List(
-            wa.fields.DelimitedList(wa.fields.Int())),
-        "dataset_id": wa.fields.Int(required=True, description="Dataset id.")
+            wa.fields.DelimitedList(wa.fields.Int()),
+            required=True
+            ),
+        "dataset_id": wa.fields.Int(required=True, description="Dataset id."),
+        "descriptions": wa.fields.Dict(description="Column descriptions")
         }, locations=["files", "form"])
     @auth_required
-    def post(self, collection_name, event_files, runs, dataset_id):
+    def post(self, collection_name, event_files, runs, dataset_id,
+             descriptions=None):
         pc, filenames = prepare_upload(
             collection_name, event_files, runs, dataset_id)
 
@@ -142,7 +146,8 @@ class PredictorCollectionResource(MethodResource):
             args=[filenames,
                   runs,
                   dataset_id,
-                  pc.id
+                  pc.id,
+                  descriptions
                   ])
 
         pc.task_id = task.id

--- a/neuroscout/tasks/upload.py
+++ b/neuroscout/tasks/upload.py
@@ -65,7 +65,8 @@ def upload_collection(flask_app, filenames, runs, dataset_id, collection_id,
     try:
         for col in common_cols - set(['onset', 'duration']):
             predictor = Predictor(
-                name=col, source=f'Collection: {collection_object.name}',
+                name=col,
+                source=f'Collection: {collection_object.collection_name}',
                 dataset_id=dataset_id,
                 description=descriptions.get(col))
             db.session.add(predictor)

--- a/neuroscout/tasks/upload.py
+++ b/neuroscout/tasks/upload.py
@@ -15,16 +15,20 @@ from .utils import update_record
 
 
 def upload_collection(flask_app, filenames, runs, dataset_id, collection_id,
-                      cache=None):
+                      descriptions=None, cache=None):
     """ Create new Predictors from TSV files
     Args:
         filenames list of (str): List of paths to TSVs
         runs list of (int): List of run ids to apply events to
         dataset_id (int): Dataset id.
         collection_id (int): Id of collection object
+        descriptions (dict): Optional descriptions for each column
+        cache (obj): Optional flask cache object
     """
     if cache is None:
         from ..core import cache as cache
+    if descriptions is None:
+        descriptions = {}
 
     collection_object = PredictorCollection.query.filter_by(
         id=collection_id).one()
@@ -61,7 +65,8 @@ def upload_collection(flask_app, filenames, runs, dataset_id, collection_id,
     try:
         for col in common_cols - set(['onset', 'duration']):
             predictor = Predictor(
-                name=col, source='upload', dataset_id=dataset_id)
+                name=col, source='upload', dataset_id=dataset_id,
+                description=descriptions.get(col))
             db.session.add(predictor)
             db.session.commit()
 

--- a/neuroscout/tasks/upload.py
+++ b/neuroscout/tasks/upload.py
@@ -65,7 +65,8 @@ def upload_collection(flask_app, filenames, runs, dataset_id, collection_id,
     try:
         for col in common_cols - set(['onset', 'duration']):
             predictor = Predictor(
-                name=col, source='upload', dataset_id=dataset_id,
+                name=col, source=f'Collection: {collection_object.name}',
+                dataset_id=dataset_id,
                 description=descriptions.get(col))
             db.session.add(predictor)
             db.session.commit()

--- a/neuroscout/tasks/viz.py
+++ b/neuroscout/tasks/viz.py
@@ -45,7 +45,7 @@ def plot_design_matrix(dm_wide, scale=True):
     ).interactive()
     line = alt.Chart(
         dm,
-        title='Regressor timecourses (shift-click above to select)').mark_line(
+        title='Timecourse (shift-click columns to select)').mark_line(
             clip=True).encode(
         alt.X('scan_number',
               axis=alt.Axis(

--- a/neuroscout/tasks/viz.py
+++ b/neuroscout/tasks/viz.py
@@ -52,7 +52,8 @@ def plot_design_matrix(dm_wide, scale=True):
                   title='Time (TRs)', values=time_labels, ticks=False),
               scale=alt.Scale(domain=(0, int(dm.scan_number.max()))),
               ),
-        y=alt.Y('value:Q', axis=alt.Axis(title='Amplitude')),
+        y=alt.Y('value:Q',
+                axis=alt.Axis(title='Amplitude (scaled for visualization)')),
         color=alt.Color(
             'regressor', sort=None, legend=alt.Legend(orient='right'))
     ).transform_filter(

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -148,6 +148,6 @@ def test_predictor_create(session,
     # Get predictor from API
     resp = decode_json(auth_client.get('/api/predictors/{}'.format(
         resp['predictors'][0]['id'])))
-    assert resp['source'] == 'upload'
+    assert resp['source'] == 'Collection: new_one'
     assert resp['name'] == 'trial_type'
     assert resp['description'] == 'new_description'

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -127,8 +127,13 @@ def test_predictor_create(session,
     pc.user_id = id_1
     session.commit()
 
+    descriptions = {
+        "trial_type": "new_description"
+    }
+
     # Submit to celery task
-    results = upload_collection(app, filenames, runs, dataset_id, pc.id)
+    results = upload_collection(app, filenames, runs, dataset_id, pc.id,
+                                descriptions)
     assert results['status'] == 'OK'
 
     resp = auth_client.get('/api/predictors/collection',
@@ -145,3 +150,4 @@ def test_predictor_create(session,
         resp['predictors'][0]['id'])))
     assert resp['source'] == 'upload'
     assert resp['name'] == 'trial_type'
+    assert resp['description'] == 'new_description'


### PR DESCRIPTION
You can now pass an object/dictionary as `descriptions` when you `POST` to /api/predictors/collection`.

This lets you set the description for each of the columns in your events. In the future, we can expand this to add more meta-data but for now I think it's all we need. 