### PR TITLE
Use derivatives = false to exclude preprocessed files

### DIFF
--- a/neuroscout/populate/ingest.py
+++ b/neuroscout/populate/ingest.py
@@ -191,7 +191,7 @@ def add_task(task_name, dataset_name=None, local_path=None,
     """ Parse every Run """
     print("Parsing runs")
     all_runs = layout.get(task=task_name, suffix='bold', extensions='.nii.gz',
-                          desc=None, **kwargs)
+                          derivatives=False, **kwargs)
     for img in progressbar(all_runs):
         """ Extract Run information """
         # Get entities


### PR DESCRIPTION
This is a better approach than using `desc=None`, which will fail if no derivatives have been linked yet. 