### PR TITLE
Index / db maintenance

### DIFF
--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -27,9 +27,6 @@ class Predictor(db.Model):
 
 class PredictorEvent(db.Model):
     """ An event within a Predictor. Onset is relative to run. """
-    __table_args__ = (
-        db.UniqueConstraint('onset', 'run_id', 'predictor_id', 'object_id'),
-    )
     id = db.Column(db.Integer, primary_key=True)
 
     onset = db.Column(db.Float, nullable=False)

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -29,7 +29,6 @@ class PredictorEvent(db.Model):
     """ An event within a Predictor. Onset is relative to run. """
     __table_args__ = (
         db.UniqueConstraint('onset', 'run_id', 'predictor_id', 'object_id'),
-        db.Index('ix_predictor_id_run_id', "predictor_id", "run_id")
     )
     id = db.Column(db.Integer, primary_key=True)
 

--- a/neuroscout/models/predictor.py
+++ b/neuroscout/models/predictor.py
@@ -38,7 +38,7 @@ class PredictorEvent(db.Model):
     object_id = db.Column(db.Integer)
 
     run_id = db.Column(db.Integer, db.ForeignKey('run.id'), nullable=False,
-                       index=True)
+                       index=False)
     predictor_id = db.Column(db.Integer, db.ForeignKey('predictor.id'),
                              nullable=False, index=True)
     stimulus_id = db.Column(db.Integer, db.ForeignKey('stimulus.id'))


### PR DESCRIPTION
There is an issue where the DB on disk is taking up 50GB. 49 of these are in the `predictor_event` tale. 

This is largely due to lack of compression / indexes, as the PG_DUMP is only ~600MB.

Well, this is also largely due to the poor decision to write the value for every predictor/onset in that table, even when the same is shown across subjects.

Here's what I get from running some stats on both `extracted_event` and `predictor_event`;

Extracted Event
![image](https://user-images.githubusercontent.com/2774448/63386749-67162e00-c369-11e9-826d-622efadb43be.png)

Predictor Event
![image](https://user-images.githubusercontent.com/2774448/63386774-75644a00-c369-11e9-8884-84c26e70dfa4.png)

This shows that from the core relation (core data stored), `predictor_event` is only about 13x larger, which makes sense given the data duplication that sometimes occurs. 

The issue seems to be indexes. I got a little index happy when we had some performance issues. 

So I ran some stats on the indexes in the db:
![image](https://user-images.githubusercontent.com/2774448/63387020-03403500-c36a-11e9-9ed0-d1ec8ab29f2c.png)

It looks like the issue is that I have too many indexes on `predictor_event`, which maybe aren't even being used. 

At least it looks like I can safely drop `ix_predictor_event_run_id`

However, I'm not sure what to do about the unique_constraint `predictor_event_onset_run_id_predictor_id_object_id_key`. According to stats, this is not being used, however, it's a nice thing to enforce. However, its massive, so I'm thinking dropping it (and hoping we don't stick duplicates in), is a good idea. 

I also want to run `REINDEX` and `VACUUM(FULL)`, but to do so I need more free space than I have... 

I'm going to see if dropping one of those indexes is enough to at least let me do that. 

Thoughts? @tyarkoni @rwblair 


