### PR TITLE
Remove PredictorEvents from Predictors derived from ExtractedFeatures

### DIFF
--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -48,7 +48,6 @@ route_factory(
         ('RunResource', 'runs/<int:run_id>'),
         ('PredictorListResource', 'predictors'),
         ('PredictorResource', 'predictors/<int:predictor_id>'),
-        ('PredictorEventListResource', 'predictor-events'),
         ('PredictorCollectionResource', 'predictors/collection'),
         ('UserRootResource', 'user'),
         ('UserTriggerResetResource', 'user/reset_password'),

--- a/neuroscout/populate/modify.py
+++ b/neuroscout/populate/modify.py
@@ -32,7 +32,7 @@ def delete_task(dataset, task):
 
 
 def extend_extracted_objects(dataset_name, **selectors):
-    """ Creates PredictorEvents for newly ingest runs in a Dataset,
+    """ Links RunStimuli for newly ingest runs in a Dataset,
         for all ExtractedFeatures. Also links derived Stimuli with new Runs.
         Args:
             dataset_name (str) - dataset name

--- a/neuroscout/resources/__init__.py
+++ b/neuroscout/resources/__init__.py
@@ -8,7 +8,6 @@ from .analysis import (AnalysisResource, AnalysisRootResource,
                        BibliographyResource)
 from .dataset import DatasetResource, DatasetListResource
 from .predictor import (PredictorListResource, PredictorResource,
-                        PredictorEventListResource,
                         PredictorCollectionResource, prepare_upload)
 from .run import RunResource, RunListResource
 from .user import (UserRootResource, UserTriggerResetResource,
@@ -31,7 +30,6 @@ __all__ = [
     'DatasetListResource',
     'PredictorResource',
     'PredictorListResource',
-    'PredictorEventListResource',
     'PredictorCollectionResource',
     'RunResource',
     'RunListResource',

--- a/neuroscout/schemas/predictor.py
+++ b/neuroscout/schemas/predictor.py
@@ -29,15 +29,6 @@ class PredictorSchema(Schema):
         return data
 
 
-class PredictorEventSchema(Schema):
-    id = fields.Str()
-    onset = fields.Number(description="Onset in seconds.")
-    duration = fields.Number(description="Duration in seconds.")
-    value = fields.Str(description="Value, or amplitude.")
-    run_id = fields.Int()
-    predictor_id = fields.Int()
-
-
 class PredictorRunSchema(Schema):
     run_id = fields.Int()
     mean = fields.Number()

--- a/neuroscout/tasks/utils.py
+++ b/neuroscout/tasks/utils.py
@@ -46,9 +46,9 @@ def write_tarball(paths, filename):
 
 def create_pes(predictors, run_ids):
     """ Create PredictorEvents from EFs """
+    all_pes = []
     for pred in predictors:
         ef = pred.extracted_feature
-        all_pes = []
         # For all instances for stimuli in this task's runs
         for ee in ef.extracted_events:
             # if ee.value:

--- a/neuroscout/tasks/utils.py
+++ b/neuroscout/tasks/utils.py
@@ -70,6 +70,7 @@ def create_pes(predictors, run_ids):
                         stimulus_id=ee.stimulus_id
                     )
                 )
+    return all_pes
 
 
 def dump_analysis(analysis_id, run_id=None):
@@ -105,5 +106,5 @@ def dump_analysis(analysis_id, run_id=None):
 
     pes += create_pes(ext_preds, run_id)
 
-    return (analysis.id, analysis_json, resources_json, dump_pe(pes),
+    return (analysis.id, analysis_json, resources_json, pes,
             analysis.dataset.local_path)

--- a/neuroscout/tasks/utils.py
+++ b/neuroscout/tasks/utils.py
@@ -2,7 +2,7 @@
 import json
 import tarfile
 from ..utils.db import put_record, dump_pe
-from ..models import Analysis, PredictorEvent
+from ..models import Analysis, PredictorEvent, Predictor, RunStimulus
 from ..schemas.analysis import AnalysisFullSchema, AnalysisResourcesSchema
 
 
@@ -44,6 +44,34 @@ def write_tarball(paths, filename):
             tar.add(path, arcname=arcname)
 
 
+def create_pes(predictors, run_ids):
+    """ Create PredictorEvents from EFs """
+    for pred in predictors:
+        ef = pred.extracted_feature
+        all_pes = []
+        # For all instances for stimuli in this task's runs
+        for ee in ef.extracted_events:
+            # if ee.value:
+            query = RunStimulus.query.filter_by(stimulus_id=ee.stimulus_id)
+            if run_ids is not None:
+                query = query.filter(RunStimulus.run_id.in_(run_ids))
+            for rs in query:
+                duration = ee.duration
+                if duration is None:
+                    duration = rs.duration
+                all_pes.append(
+                    dict(
+                        onset=(ee.onset or 0) + rs.onset,
+                        value=ee.value,
+                        object_id=ee.object_id,
+                        duration=duration,
+                        predictor_id=pred.id,
+                        run_id=rs.run_id,
+                        stimulus_id=ee.stimulus_id
+                    )
+                )
+
+
 def dump_analysis(analysis_id, run_id=None):
     """" Serialize analysis and related PredictorEvents to JSON.
     Queries PredictorEvents to get all events for all runs and predictors. """
@@ -55,18 +83,27 @@ def dump_analysis(analysis_id, run_id=None):
     analysis_json = AnalysisFullSchema().dump(analysis)[0]
     resources_json = AnalysisResourcesSchema().dump(analysis)[0]
 
-    # Query and dump PredictorEvents
-    pred_ids = [p['id'] for p in analysis_json['predictors']]
+    # Get run IDs
     all_runs = [r['id'] for r in analysis_json['runs']]
-
     if run_id is None:
         run_id = all_runs
     if not set(run_id) <= set(all_runs):
         raise ValueError("Incorrect run id specified")
 
+    # Query and dump PredictorEvents
+    all_pred_ids = [(p['id']) for p in analysis_json['predictors']]
+    all_preds = Predictor.query.filter(Predictor.id.in_(all_pred_ids))
+
+    base_pred_ids = [p.id for p in all_preds.filter_by(ef_id=None)]
+    ext_preds = Predictor.query.filter(
+        Predictor.id.in_(set(all_pred_ids) - set(base_pred_ids)))
+
     pes = PredictorEvent.query.filter(
-        (PredictorEvent.predictor_id.in_(pred_ids)) &
+        (PredictorEvent.predictor_id.in_(base_pred_ids)) &
         (PredictorEvent.run_id.in_(run_id)))
+    pes = dump_pe(pes)
+
+    pes += create_pes(ext_preds, run_id)
 
     return (analysis.id, analysis_json, resources_json, dump_pe(pes),
             analysis.dataset.local_path)

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -83,24 +83,6 @@ def test_get_rextracted(auth_client, reextract):
     assert len(decode_json(resp)) == 5
 
 
-def test_get_predictor_data(auth_client, add_task):
-    # List of predictors
-    resp = auth_client.get('/api/predictor-events')
-    assert resp.status_code == 200
-    pe_list = decode_json(resp)
-    assert len(pe_list) == 36
-
-    pe = pe_list[0]
-    # Get PEs only for one run
-    resp = auth_client.get(
-        '/api/predictor-events',
-        params={'predictor_id': pe['predictor_id'], 'run_id': pe['run_id']})
-
-    assert resp.status_code == 200
-    pe_list_filt = decode_json(resp)
-    assert len(pe_list_filt) == 4
-
-
 def test_predictor_create(session,
                           auth_client, add_users, add_task, get_data_path):
     # Mock request to /predictors/create

--- a/neuroscout/tests/conftest.py
+++ b/neuroscout/tests/conftest.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 import pandas as pd
 from flask import current_app
 from ..models import (Analysis, Predictor,
-                      PredictorEvent, User, Role, Dataset)
+                      PredictorRun, User, Role, Dataset)
 from .. import populate
 
 """
@@ -189,8 +189,8 @@ def add_analysis(session, add_users, add_task, extract_features):
         runs=dataset.runs)
 
     run_id = [r.id for r in dataset.runs]
-    pred_id = PredictorEvent.query.filter(
-        PredictorEvent.run_id.in_(run_id)).distinct(
+    pred_id = PredictorRun.query.filter(
+        PredictorRun.run_id.in_(run_id)).distinct(
             'predictor_id').with_entities('predictor_id').all()
 
     analysis.predictors = Predictor.query.filter(

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -122,14 +122,7 @@ def test_extracted_features(session, add_task, extract_features):
 
     # Check that the number of features extracted is the same as Stimuli
     assert len(ef_b.extracted_events) == Stimulus.query.count()
-
-    # Check for sensical value
-    assert isclose(float(session.query(func.max(PredictorEvent.value)).join(
-        Predictor).filter_by(ef_id=ef_b.id).one()[0]), 0.88, 0.1)
-
-    # And that a sensical onset was extracted
-    assert session.query(func.max(PredictorEvent.onset)).join(
-        Predictor).filter_by(ef_id=ef_b.id).one()[0] == 25.0
+    
 
     # Test that Predictors were created from EF
     pred = Predictor.query.filter_by(ef_id=ef_b.id).one()

--- a/neuroscout/tests/test_models.py
+++ b/neuroscout/tests/test_models.py
@@ -122,7 +122,6 @@ def test_extracted_features(session, add_task, extract_features):
 
     # Check that the number of features extracted is the same as Stimuli
     assert len(ef_b.extracted_events) == Stimulus.query.count()
-    
 
     # Test that Predictors were created from EF
     pred = Predictor.query.filter_by(ef_id=ef_b.id).one()


### PR DESCRIPTION
Fixes #642 

It's easy enough (if a bit redundant) to dynamically generate `PredictorEvents` for `Predictors` from extractors. It remains to be seem how slow this is (especially for Reports).

However, we still need the `PredictorEvent` table for `Predictors` that come from event files (and could differ between subjects), and uploaded PredictorCollection (as they don't link to stimuli). We could potentially add another table here to reduce redundancy but it doesn't seem worth it. 