### PR TITLE
Link directly to NeuroScout in NeuroVault

### DIFF
--- a/neuroscout/resources/analysis/reports.py
+++ b/neuroscout/resources/analysis/reports.py
@@ -134,8 +134,7 @@ def _create_collection(analysis, force=False):
         collection = api.create_collection(
             collection_name,
             description=analysis.description,
-            paper_url=url,
-            full_dataset_url=analysis.dataset.url)
+            full_dataset_url=url)
     except Exception:
         abort(422, "Error creating collection, "
                    "perhaps one with that name already exists?")


### PR DESCRIPTION
NV only displays the full_dataset_url. We were using that to link back to the raw data, but until NeuroVault/NeuroVault#723 is implemented, we can use the full_dataset_url.