### PR TITLE
Migrate domain to bare neuroscout.org and add redirect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   swagger-ui:
     image: swaggerapi/swagger-ui
     environment:
-      - "API_URL=https://alpha.neuroscout.org/swagger/"
+      - "API_URL=https://neuroscout.org/swagger/"
     expose:
       - '8080'
 

--- a/neuroscout/frontend/package.json
+++ b/neuroscout/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "version": "0.1.0",
-  "proxy": "http://alpha.neuroscout.org:80",
+  "proxy": "http://neuroscout.org:80",
   "private": true,
   "dependencies": {
     "@types/antd": "^1.0.0",

--- a/neuroscout/frontend/src/config.ts.example
+++ b/neuroscout/frontend/src/config.ts.example
@@ -1,5 +1,5 @@
 export const config =  {
-  'server_url': 'https://alpha.neuroscout.org',
+  'server_url': 'https://neuroscout.org',
   'google_client_id': 'GOOGLE_CLIENT_ID',
   'ga_key': 'GAKEY'
 };

--- a/nginx/sites-enabled/flask_project
+++ b/nginx/sites-enabled/flask_project
@@ -1,15 +1,28 @@
 server {
+        server_name alpha.neuroscout.org www.neuroscout.org;
+        charset utf-8;
+        listen      443           ssl http2;
+        listen [::]:443           ssl http2;
 
-    server_name alpha.neuroscout.org;
+        ssl_certificate           /etc/letsencrypt/live/neuroscout.org-0002/fullchain.pem;
+        ssl_certificate_key       /etc/letsencrypt/live/neuroscout.org-0002/privkey.pem;
+        ssl_trusted_certificate   /etc/letsencrypt/live/neuroscout.org-0002/chain.pem;
+
+        return 301 $scheme://neuroscout.org$request_uri;
+}
+
+server {
+
+    server_name neuroscout.org;
     charset utf-8;
     listen      443           ssl http2;
     listen [::]:443           ssl http2;
 
     root /neuroscout/neuroscout/frontend/build;
 
-    ssl_certificate           /etc/letsencrypt/live/alpha.neuroscout.org/fullchain.pem;
-    ssl_certificate_key       /etc/letsencrypt/live/alpha.neuroscout.org/privkey.pem;
-    ssl_trusted_certificate   /etc/letsencrypt/live/alpha.neuroscout.org/chain.pem;
+    ssl_certificate           /etc/letsencrypt/live/neuroscout.org-0002/fullchain.pem;
+    ssl_certificate_key       /etc/letsencrypt/live/neuroscout.org-0002/privkey.pem;
+    ssl_trusted_certificate   /etc/letsencrypt/live/neuroscout.org-0002/chain.pem;
 
     ssl_protocols TLSv1.2;# Requires nginx >= 1.13.0 else use TLSv1.2
     ssl_prefer_server_ciphers on;

--- a/nginx/sites-enabled/ssl_config
+++ b/nginx/sites-enabled/ssl_config
@@ -1,5 +1,5 @@
 server {
-     server_name alpha.neuroscout.org;
+     server_name neuroscout.org www.neuroscout.org alpha.neuroscout.org;
 
      location /.well-known {
          allow all;


### PR DESCRIPTION
Adds redirect from `alpha.neuroscout.org` to `neuroscout.org` and changes the official domain to the latter.

@tyarkoni can you check that the DNS for `www.neuroscout.org` is set up correctly? I was able to extend the cert to include the bare domain and alpha, but www. does not work. (Now I'm timed out from trying again for a while)