### PR TITLE
added warning on google accounts and pyNS

### DIFF
--- a/docs/builder/index.md
+++ b/docs/builder/index.md
@@ -9,6 +9,9 @@ Currently, there are two supported options, the choice is yours!
 
 If you create an account with us, you'll be asked to validate your email, as usual.
 
+!!! Warning
+    Note that Google accounts are currently not supported by the Neuroscout API wrapper [pyNS](https://github.com/neuroscout/pyNS). To interact withe API using pyNS, create an account using email and password.
+
 
 !!! Note
     Accounts are linked using email addresses. Signing up twice using the same email address, will result in a single account.


### PR DESCRIPTION
edited "getting started" in documentation with warning on Google accounts not being supported when accessing API via pyNS.