### PR TITLE
force reconstruct of review tab for fresh results on model change

### DIFF
--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -1219,12 +1219,12 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
                   <br/>
                 </TabPane>}
                 <TabPane tab="Review" key="review" disabled={((!reviewActive || !analysis.analysisId) && isDraft)}>
-                  {this.state.model &&
+                  {this.state.model && this.state.activeTab === ('review' as TabName) &&
                     <div>
                       <Report
                         analysisId={analysis.analysisId}
                         runIds={analysis.runIds}
-                        postReports={this.state.postReports}
+                        postReports={this.state.activeTab === ('review' as TabName)}
                         defaultVisible={this.state.doTooltip && this.state.activeTab === ('review' as TabName)}
                       />
                       <Review


### PR DESCRIPTION
This is inefficient, every time the review tab is navigated to it hits the api to redownload results.

Before I had the conditional around the reports tab in builder the report state would properly update with the new reports as necessary but the default active plot in the plots tabs would not rerender with the new results.