### PR TITLE
Add ability to generate and view reports for any run.

### DIFF
--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -1066,6 +1066,7 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
       unsavedChanges
     } = this.state;
 
+    let reportRuns = this.state.availableRuns.filter(x => this.state.analysis.runIds.find(runId => runId === x.id));
     let isDraft = (analysis.status === 'DRAFT');
     let isFailed = (analysis.status === 'FAILED');
     let isEditable = editableStatus.includes(analysis.status);
@@ -1223,7 +1224,7 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
                     <div>
                       <Report
                         analysisId={analysis.analysisId}
-                        runIds={analysis.runIds}
+                        runs={reportRuns}
                         postReports={this.state.activeTab === ('review' as TabName)}
                         defaultVisible={this.state.doTooltip && this.state.activeTab === ('review' as TabName)}
                       />

--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -41,7 +41,7 @@ import {
   TransformName,
   TabName
 } from '../coretypes';
-import { displayError, jwtFetch, timeout, isDefined } from '../utils';
+import { displayError, jwtFetch, sortSub, timeout, isDefined } from '../utils';
 import { MainCol, Space } from '../HelperComponents';
 import { config } from '../config';
 
@@ -471,6 +471,7 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
         if (data.hash_id !== undefined) {
           analysisId = data.hash_id;
         }
+
         this.setState({
           analysis: {
             ...analysis,
@@ -479,7 +480,7 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
             modifiedAt: data.modified_at
           },
           postReports: analysis.contrasts.length > 0,
-          unsavedChanges: false
+          unsavedChanges: false,
         });
         // will this mess with /fill workflow?
         // can't remember reason behind having to call this so often
@@ -563,11 +564,12 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
         .then(fetch_data => {
           this.setState({ selectedTaskId: fetch_data.task.id });
           this.updateState('analysis', true)(analysis);
-        })
+         })
         .catch(displayError);
     } else {
       this.updateState('analysis', true)(analysis);
     }
+
     this.setActiveTabs(analysis);
     return Promise.resolve(analysis);
   };
@@ -1066,7 +1068,9 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
       unsavedChanges
     } = this.state;
 
-    let reportRuns = this.state.availableRuns.filter(x => this.state.analysis.runIds.find(runId => runId === x.id));
+    let reportRuns = this.state.availableRuns.filter(
+      x => this.state.analysis.runIds.find(runId => runId === x.id)
+    ).sort(sortSub);
     let isDraft = (analysis.status === 'DRAFT');
     let isFailed = (analysis.status === 'FAILED');
     let isEditable = editableStatus.includes(analysis.status);
@@ -1220,13 +1224,14 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
                   <br/>
                 </TabPane>}
                 <TabPane tab="Review" key="review" disabled={((!reviewActive || !analysis.analysisId) && isDraft)}>
-                  {this.state.model && this.state.activeTab === ('review' as TabName) &&
+                  {this.state.model && activeTab === ('review' as TabName) && reportRuns.length > 0 &&
                     <div>
                       <Report
                         analysisId={analysis.analysisId}
                         runs={reportRuns}
-                        postReports={this.state.activeTab === ('review' as TabName)}
+                        postReports={activeTab === ('review' as TabName)}
                         defaultVisible={this.state.doTooltip && this.state.activeTab === ('review' as TabName)}
+                        activeTab={activeTab}
                       />
                       <Review
                         model={this.state.model}

--- a/neuroscout/frontend/src/analysis_builder/Overview.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Overview.tsx
@@ -8,6 +8,7 @@ import { ColumnProps, TableRowSelection } from 'antd/lib/table';
 import { getTasks } from './Builder';
 import { Analysis, Dataset, Run, Task } from '../coretypes';
 import { datasetColumns } from '../HelperComponents';
+import { sortSub, sortNum, sortSes } from '../utils';
 
 const FormItem = Form.Item;
 const Panel = Collapse.Panel;
@@ -83,9 +84,9 @@ export class OverviewTab extends React.Component<OverviewTabProps, OverviewTabSt
     }
 
     if (this.props.availableRuns.length !== prevProps.availableRuns.length) {
-      let subCol = this.makeCol('Subject', 'subject', this.sortSub);
-      let runCol = this.makeCol('Run Number', 'number', this.sortNum);
-      let sesCol = this.makeCol('Session', 'session', this.sortSes);
+      let subCol = this.makeCol('Subject', 'subject', sortSub);
+      let runCol = this.makeCol('Run Number', 'number', sortNum);
+      let sesCol = this.makeCol('Session', 'session', sortSes);
       let _runColumns = [subCol, runCol, sesCol].filter(x => x !== undefined) as ColumnProps<any>[];
       if (_runColumns[0]) { _runColumns[0].defaultSortOrder = 'ascend' as 'ascend'; }
       if (this.state.clearFilteredVal) {
@@ -94,22 +95,6 @@ export class OverviewTab extends React.Component<OverviewTabProps, OverviewTabSt
       this.setState({runColumns: _runColumns, clearFilteredVal: false});
     }
   }
-
-  // Number column can be a mixture of ints and strings sometimes, hence the cast to string
-  // number is stored as text in postgres, should see about treating it consistently in app
-  _sortRuns = (keys, a, b) => {
-    for (var i = 0; i < keys.length; i++) {
-      let _a = String(a[keys[i]]);
-      let _b = String(b[keys[i]]);
-      let cmp = _a.localeCompare(_b, undefined, {numeric: true});
-      if (cmp !== 0) { return cmp; }
-    }
-    return 0;
-  }
-
-  sortSub = this._sortRuns.bind(null, ['subject', 'number', 'session']);
-  sortNum = this._sortRuns.bind(null, ['number', 'subject',  'session']);
-  sortSes = this._sortRuns.bind(null, ['session', 'subject', 'number']);
 
   /* Run column settings were largely similar, this function creates them.
      The cast to String before sort is to account for run numbers being a
@@ -298,7 +283,7 @@ export class OverviewTab extends React.Component<OverviewTabProps, OverviewTabSt
                   columns={this.state.runColumns}
                   rowKey="id"
                   size="small"
-                  dataSource={availableRuns.filter(r => r.task === selectedTaskId).sort(this.sortSub)}
+                  dataSource={availableRuns.filter(r => r.task === selectedTaskId).sort(sortSub)}
                   pagination={(availableRuns.length > 10) ? {'position': 'bottom'} : false}
                   rowSelection={runRowSelection}
                   onChange={this.applyFilter}

--- a/neuroscout/frontend/src/analysis_builder/Report.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Report.tsx
@@ -260,14 +260,14 @@ export class Report extends React.Component<ReportProps, ReportState> {
  
   formatRun = (run: Run) => {
     let ret = '';
-    if (!!run.number) {
-      ret = ret.concat('Run - ', run.number, ' ');
+    if (!!run.subject) {
+      ret = ret.concat('subject - ', run.subject, ' ');
     }
     if (!!run.session) {
       ret = ret.concat('Session - ', run.session, ' ');
     }
-    if (!!run.subject) {
-      ret = ret.concat('subject - ', run.subject, ' ');
+    if (!!run.number) {
+      ret = ret.concat('Run - ', run.number, ' ');
     }
     if (ret === '') {
       ret = run.id;

--- a/neuroscout/frontend/src/analysis_builder/Report.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Report.tsx
@@ -103,6 +103,7 @@ interface ReportState {
 export class Report extends React.Component<ReportProps, ReportState> {
   constructor(props) {
     super(props);
+    this._timer = null;
     let state: ReportState = {
       matrices: [],
       plots: [],
@@ -119,6 +120,8 @@ export class Report extends React.Component<ReportProps, ReportState> {
     this.state = state;
   }
 
+  _timer: any = null;
+
   generateReport = (): void => {
     let id = this.props.analysisId;
     let url = `${domainRoot}/api/analyses/${id}/report?run_id=${this.state.selectedRunIds}`;
@@ -128,9 +131,18 @@ export class Report extends React.Component<ReportProps, ReportState> {
   };
 
   checkReportStatus = async () => {
-    while (!this.state.reportsLoaded) {
-      this.loadReports();
-      await timeout(3000);
+    if (this._timer === null) {
+      this._timer = setInterval(
+        () => {
+          if (this.state.reportsLoaded) {
+            clearInterval(this._timer);
+            this._timer = null;
+          } else {
+            this.loadReports();
+          }
+        },
+        4000
+      );
     }
   };
 
@@ -217,6 +229,11 @@ export class Report extends React.Component<ReportProps, ReportState> {
     if (prevState.reportsLoaded === true && this.state.reportsLoaded === false) {
       this.checkReportStatus();
     }
+  }
+
+  componentWillUnmount() {
+    clearInterval(this._timer);
+    this._timer = null;
   }
 
   updateReports = () => {

--- a/neuroscout/frontend/src/analysis_builder/Report.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Report.tsx
@@ -33,7 +33,7 @@ class VegaPlot extends React.Component<{spec: string}, {}> {
   }
 }
 
-class Plots extends React.Component<{plots: any[], corr_plots: any[], runTitles: string[]}, {}> {
+class Plots extends React.Component<{matrices: string[], plots: any[], corr_plots: any[], runTitles: string[]}, {}> {
     plotContainer;
     constructor(props) {
       super(props);
@@ -49,6 +49,7 @@ class Plots extends React.Component<{plots: any[], corr_plots: any[], runTitles:
             <Collapse bordered={false} defaultActiveKey={['dm']}>
              <Panel header="Design Matrix" key="dm">
               <VegaPlot spec={this.props.plots[i]}/>
+              <a href={this.props.matrices[i]}>Download Design Matrix</a>
              </Panel>
              <Panel header="Correlation Matrix" key="cm">
               <VegaPlot spec={this.props.corr_plots[i]}/>
@@ -166,7 +167,6 @@ export class Report extends React.Component<ReportProps, ReportState> {
         if (res.result === undefined) {
           return;
         }
-
         state.matrices = res.result.design_matrix;
         state.plots = res.result.design_matrix_plot;
         state.corr_plots = res.result.design_matrix_corrplot;
@@ -355,7 +355,12 @@ export class Report extends React.Component<ReportProps, ReportState> {
               </Popconfirm>
             </div>
 
-            <Plots plots={this.state.plots} corr_plots={this.state.corr_plots} runTitles={this.state.runTitles}/>
+            <Plots
+              matrices={this.state.matrices}
+              plots={this.state.plots}
+              corr_plots={this.state.corr_plots}
+              runTitles={this.state.runTitles}
+            />
           </Spin>
         </Card>
         <br/>

--- a/neuroscout/frontend/src/analysis_builder/Report.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Report.tsx
@@ -66,12 +66,14 @@ class Plots extends React.Component<{plots: any[], corr_plots: any[], runTitles:
           <TabPane tab={this.props.runTitles[i]} key={'' + i}>
             <Collapse bordered={false} defaultActiveKey={['dm']}>
              <Panel header="Design Matrix" key="dm">
-              <VegaPlot spec={this.props.plots[i]}/>
+               <VegaPlot
+                 spec={this.props.plots[i]}
+                 title={this.props.runTitles[i].replace(/ /g, '').concat('.png')}
+               />
              </Panel>
              <Panel header="Correlation Matrix" key="cm">
                <VegaPlot
                  spec={this.props.corr_plots[i]}
-                 title={this.props.runTitles[i].replace(/ /g, '').concat('.png')}
                />
              </Panel>
             </Collapse>

--- a/neuroscout/frontend/src/analysis_builder/Report.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Report.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import { Button, Tabs, Collapse, Card, Tooltip, Icon, Select, Spin, Popconfirm, Anchor } from 'antd';
+import { Button, Tabs, Collapse, Card, Tooltip, Icon, Select, Spin, Popconfirm } from 'antd';
 import vegaEmbed from 'vega-embed';
 
 import { OptionProps } from 'antd/lib/select';
-
-import { View as view_t } from 'vega-typings';
 
 import { config } from '../config';
 import { jwtFetch, timeout } from '../utils';
@@ -12,40 +10,25 @@ import { jwtFetch, timeout } from '../utils';
 import { Run, TabName } from '../coretypes';
 const domainRoot = config.server_url;
 
-const { TabPane } = Tabs;
-const { Panel } = Collapse;
+const TabPane = Tabs.TabPane;
+const Panel = Collapse.Panel;
 const { Option } = Select;
-const { Link } = Anchor;
 
-class VegaPlot extends React.Component<{spec: string, title?: string}, {imageUrl?: string}> {
+class VegaPlot extends React.Component<{spec: string}, {}> {
   vegaContainer;
 
   constructor(props) {
     super(props);
     this.vegaContainer = React.createRef();
-    this.state = {imageUrl: ''};
   }
 
   componentDidMount() {
-      vegaEmbed(this.vegaContainer.current, this.props.spec, { renderer: 'svg' })
-      .then((result) => { return result.view.toImageURL('png'); })
-      .then((res) => this.setState({imageUrl: res}));
-
+      vegaEmbed(this.vegaContainer.current, this.props.spec, { renderer: 'svg' });
   }
 
   render () {
     return(
-      <>
-        <div ref={this.vegaContainer}/>
-        { this.props.title && !!this.state.imageUrl &&
-        <>
-          <br />
-          <a href={this.state.imageUrl} download={this.props.title}>
-            Download as PNG
-          </a>
-        </>
-        }
-      </>
+      <div ref={this.vegaContainer}/>
     );
   }
 }
@@ -58,7 +41,6 @@ class Plots extends React.Component<{plots: any[], corr_plots: any[], runTitles:
     }
 
     render() {
-
       let display: any[] = [];
       this.props.plots.map((x, i) => {
         let spec = x;
@@ -69,10 +51,7 @@ class Plots extends React.Component<{plots: any[], corr_plots: any[], runTitles:
               <VegaPlot spec={this.props.plots[i]}/>
              </Panel>
              <Panel header="Correlation Matrix" key="cm">
-               <VegaPlot
-                 spec={this.props.corr_plots[i]}
-                 title={this.props.runTitles[i].replace(/ /g, '').concat('.png')}
-               />
+              <VegaPlot spec={this.props.corr_plots[i]}/>
              </Panel>
             </Collapse>
           </TabPane>

--- a/neuroscout/frontend/src/analysis_builder/Report.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Report.tsx
@@ -2,10 +2,12 @@ import * as React from 'react';
 import { Button, Tabs, Collapse, Card, Tooltip, Icon, Select, Spin } from 'antd';
 import vegaEmbed from 'vega-embed';
 
+import { OptionProps } from 'antd/lib/select';
+
 import { config } from '../config';
 import { jwtFetch, timeout } from '../utils';
 
-import { Run } from '../coretypes';
+import { Run, TabName } from '../coretypes';
 const domainRoot = config.server_url;
 
 const TabPane = Tabs.TabPane;
@@ -29,7 +31,6 @@ class VegaPlot extends React.Component<{spec: string}, {}> {
       <div ref={this.vegaContainer}/>
     );
   }
-
 }
 
 class Plots extends React.Component<{plots: any[], corr_plots: any[], runTitles: string[]}, {}> {
@@ -81,6 +82,7 @@ interface ReportProps {
   runs: Run[];
   postReports: boolean;
   defaultVisible: boolean;
+  activeTab: TabName;
 }
 
 interface ReportState {
@@ -177,10 +179,8 @@ export class Report extends React.Component<ReportProps, ReportState> {
   }
 
   updateSelectedRunIds = (values: string[]) => {
-    let runTitles =  this.props.runs.filter(x => values.includes('' + x.id)).map(x => this.formatRun(x));
     this.setState({
-      selectedRunIds: values,
-      runTitles: runTitles
+      selectedRunIds: values
     });
   }
 
@@ -220,12 +220,25 @@ export class Report extends React.Component<ReportProps, ReportState> {
   }
 
   updateReports = () => {
+    let runTitles =  this.props.runs.filter((x) => {
+      return this.state.selectedRunIds.includes('' + x.id);
+    }).map(x => this.formatRun(x));
+
     this.setState(
       {
         reportsLoaded: false,
-        reportsPosted: false
+        reportsPosted: false,
+        runTitles: runTitles
       }
     );
+  }
+
+  filterRuns = (inputValue: string, option:  React.ReactElement<OptionProps>): boolean => {
+    
+    if (option.props.children) {
+      return ('' + option.props.children).includes(inputValue);
+    }
+    return false;
   }
  
   formatRun = (run: Run) => {
@@ -277,6 +290,7 @@ export class Report extends React.Component<ReportProps, ReportState> {
               <Select
                 mode="multiple"
                 onChange={this.updateSelectedRunIds}
+                filterOption={this.filterRuns}
                 defaultValue={this.state.selectedRunIds}
                 className="plotRunSelector"
               >
@@ -308,4 +322,3 @@ export class Report extends React.Component<ReportProps, ReportState> {
     );
   }
 }
-// <Status status={this.state.status} analysisId={this.props.analysisId} />

--- a/neuroscout/frontend/src/analysis_builder/Report.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Report.tsx
@@ -66,14 +66,12 @@ class Plots extends React.Component<{plots: any[], corr_plots: any[], runTitles:
           <TabPane tab={this.props.runTitles[i]} key={'' + i}>
             <Collapse bordered={false} defaultActiveKey={['dm']}>
              <Panel header="Design Matrix" key="dm">
-               <VegaPlot
-                 spec={this.props.plots[i]}
-                 title={this.props.runTitles[i].replace(/ /g, '').concat('.png')}
-               />
+              <VegaPlot spec={this.props.plots[i]}/>
              </Panel>
              <Panel header="Correlation Matrix" key="cm">
                <VegaPlot
                  spec={this.props.corr_plots[i]}
+                 title={this.props.runTitles[i].replace(/ /g, '').concat('.png')}
                />
              </Panel>
             </Collapse>

--- a/neuroscout/frontend/src/analysis_builder/Report.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Report.tsx
@@ -49,6 +49,7 @@ class Plots extends React.Component<{matrices: string[], plots: any[], corr_plot
             <Collapse bordered={false} defaultActiveKey={['dm']}>
              <Panel header="Design Matrix" key="dm">
               <VegaPlot spec={this.props.plots[i]}/>
+              <br/>
               <a href={this.props.matrices[i]}>Download Design Matrix</a>
              </Panel>
              <Panel header="Correlation Matrix" key="cm">

--- a/neuroscout/frontend/src/css/App.css
+++ b/neuroscout/frontend/src/css/App.css
@@ -129,3 +129,17 @@ pre {
   height: 32px;
   padding: 0px 15px;
 } 
+
+.plotRunSelectorContainer {
+    display: flex;
+    margin: 10px 0;
+}
+
+.plotRunSelector {
+    flex: 1;
+}
+
+.plotRunSelectorBtn {
+    margin: 0 0 0 10px;
+    float: right;
+}

--- a/neuroscout/frontend/src/utils/index.ts
+++ b/neuroscout/frontend/src/utils/index.ts
@@ -109,3 +109,20 @@ export const reorder = (list: any[], startIndex: number, endIndex: number): any[
 export const isDefined = <T>(argument: T | undefined): argument is T => {
     return argument !== undefined;
 };
+
+// Number column can be a mixture of ints and strings sometimes, hence the cast to string
+// number is stored as text in postgres, should see about treating it consistently in app
+const _sortRuns = (keys, a, b) => {
+  for (var i = 0; i < keys.length; i++) {
+    let _a = String(a[keys[i]]);
+    let _b = String(b[keys[i]]);
+    let cmp = _a.localeCompare(_b, undefined, {numeric: true});
+    if (cmp !== 0) { return cmp; }
+  }
+  return 0;
+};
+
+// Comparison functions to pass to sort for arrays of type Run by differnt keys
+export const sortSub = _sortRuns.bind(null, ['subject', 'number', 'session']);
+export const sortNum = _sortRuns.bind(null, ['number', 'subject',  'session']);
+export const sortSes = _sortRuns.bind(null, ['session', 'subject', 'number']);


### PR DESCRIPTION
Fixes #533 #686 

Currently no warning on number of runs selected. @adelavega any idea at what number we might want to warn at?

This also assumes that the api returns run plots in the same order that front end asks for them.