### PR TITLE
Restore predictor-events route, dumps extracted events

### DIFF
--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -49,6 +49,7 @@ route_factory(
         ('PredictorListResource', 'predictors'),
         ('PredictorResource', 'predictors/<int:predictor_id>'),
         ('PredictorCollectionResource', 'predictors/collection'),
+        ('PredictorEventListResource', 'predictor-events'),
         ('UserRootResource', 'user'),
         ('UserTriggerResetResource', 'user/reset_password'),
         ('UserResetSubmitResource', 'user/submit_token'),

--- a/neuroscout/resources/__init__.py
+++ b/neuroscout/resources/__init__.py
@@ -8,7 +8,8 @@ from .analysis import (AnalysisResource, AnalysisRootResource,
                        BibliographyResource)
 from .dataset import DatasetResource, DatasetListResource
 from .predictor import (PredictorListResource, PredictorResource,
-                        PredictorCollectionResource, prepare_upload)
+                        PredictorCollectionResource, prepare_upload,
+                        PredictorEventListResource)
 from .run import RunResource, RunListResource
 from .user import (UserRootResource, UserTriggerResetResource,
                    UserResetSubmitResource, UserResendConfirm,
@@ -31,6 +32,7 @@ __all__ = [
     'DatasetListResource',
     'PredictorResource',
     'PredictorListResource',
+    'PredictorEventListResource',
     'PredictorCollectionResource',
     'RunResource',
     'RunListResource',

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -161,7 +161,7 @@ class PredictorCollectionResource(MethodResource):
 
 class PredictorEventListResource(MethodResource):
     @doc(tags=['predictors'], summary='Get events for predictor(s)',)
-    @marshal_with(PredictorEventSchema)
+    @marshal_with(PredictorEventSchema(many=True))
     @use_kwargs({
         'run_id': wa.fields.DelimitedList(
             wa.fields.Int(),

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -11,9 +11,11 @@ from ..models import (
     Predictor, PredictorRun, PredictorCollection)
 from ..database import db
 from ..core import cache
-from ..schemas.predictor import PredictorSchema, PredictorCollectionSchema
+from ..schemas.predictor import (
+    PredictorSchema, PredictorEventSchema, PredictorCollectionSchema)
 from ..api_spec import FileField
 from ..worker import celery_app
+from ..utils.db import dump_predictor_events
 
 
 class PredictorResource(MethodResource):
@@ -155,3 +157,20 @@ class PredictorCollectionResource(MethodResource):
     def get(self, collection_id):
         return first_or_404(
             PredictorCollection.query.filter_by(id=collection_id))
+
+
+class PredictorEventListResource(MethodResource):
+    @doc(tags=['predictors'], summary='Get events for predictor(s)',)
+    @marshal_with(PredictorEventSchema)
+    @use_kwargs({
+        'run_id': wa.fields.DelimitedList(
+            wa.fields.Int(),
+            description="Run id(s)"),
+        'predictor_id': wa.fields.DelimitedList(
+            wa.fields.Int(),
+            description="Predictor id(s)",
+            required=True),
+    }, locations=['query'])
+    @cache.cached(60 * 60 * 24 * 300, query_string=True)
+    def get(self, predictor_id, run_id=None):
+        return dump_predictor_events(predictor_id, run_id)

--- a/neuroscout/schemas/predictor.py
+++ b/neuroscout/schemas/predictor.py
@@ -15,8 +15,8 @@ class PredictorSchema(Schema):
     description = fields.Str(description="Predictor description")
     extracted_feature = fields.Nested('ExtractedFeatureSchema', skip_if=None)
     source = fields.Str()
-    private = fields.Boolean(description="Predictor visible to the public or not")
-
+    private = fields.Boolean(
+        description="Predictor visible to the public or not")
     max = fields.Float(description="Maximum value")
     min = fields.Float(description="Minimum value")
     mean = fields.Float(description="Mean value")
@@ -47,3 +47,12 @@ class PredictorCollectionSchema(Schema):
     collection_name = fields.Str(description='Name of collection')
     predictors = fields.Nested(
         'PredictorSchema', many=True)
+
+
+class PredictorEventSchema(Schema):
+    id = fields.Str()
+    onset = fields.Number(description="Onset in seconds.")
+    duration = fields.Number(description="Duration in seconds.")
+    value = fields.Str(description="Value, or amplitude.")
+    run_id = fields.Int()
+    predictor_id = fields.Int()

--- a/neuroscout/schemas/predictor.py
+++ b/neuroscout/schemas/predictor.py
@@ -50,7 +50,6 @@ class PredictorCollectionSchema(Schema):
 
 
 class PredictorEventSchema(Schema):
-    id = fields.Str()
     onset = fields.Number(description="Onset in seconds.")
     duration = fields.Number(description="Duration in seconds.")
     value = fields.Str(description="Value, or amplitude.")

--- a/neuroscout/tasks/utils/io.py
+++ b/neuroscout/tasks/utils/io.py
@@ -3,8 +3,8 @@ import json
 import tarfile
 from pathlib import Path
 from grabbit.extensions.writable import build_path
-from ...utils.db import put_record, dump_pe
-from ...models import Analysis, PredictorEvent, Predictor, RunStimulus
+from ...utils.db import put_record, dump_predictor_events
+from ...models import Analysis
 from ...schemas.analysis import AnalysisFullSchema, AnalysisResourcesSchema
 
 REPORT_PATHS = ['sub-{subject}_[ses-{session}_]task-{task}_'
@@ -66,35 +66,6 @@ class PathBuilder():
         return outfile, '{}/reports/{}/{}'.format(self.domain, self.hash, file)
 
 
-def create_pes(predictors, run_ids):
-    """ Create PredictorEvents from EFs """
-    all_pes = []
-    for pred in predictors:
-        ef = pred.extracted_feature
-        # For all instances for stimuli in this task's runs
-        for ee in ef.extracted_events:
-            # if ee.value:
-            query = RunStimulus.query.filter_by(stimulus_id=ee.stimulus_id)
-            if run_ids is not None:
-                query = query.filter(RunStimulus.run_id.in_(run_ids))
-            for rs in query:
-                duration = ee.duration
-                if duration is None:
-                    duration = rs.duration
-                all_pes.append(
-                    dict(
-                        onset=(ee.onset or 0) + rs.onset,
-                        value=ee.value,
-                        object_id=ee.object_id,
-                        duration=duration,
-                        predictor_id=pred.id,
-                        run_id=rs.run_id,
-                        stimulus_id=ee.stimulus_id
-                    )
-                )
-    return all_pes
-
-
 def dump_analysis(analysis_id, run_id=None):
     """" Serialize analysis and related PredictorEvents to JSON.
     Queries PredictorEvents to get all events for all runs and predictors. """
@@ -113,20 +84,10 @@ def dump_analysis(analysis_id, run_id=None):
     if not set(run_id) <= set(all_runs):
         raise ValueError("Incorrect run id specified")
 
-    # Query and dump PredictorEvents
-    all_pred_ids = [(p['id']) for p in analysis_json['predictors']]
-    all_preds = Predictor.query.filter(Predictor.id.in_(all_pred_ids))
-
-    base_pred_ids = [p.id for p in all_preds.filter_by(ef_id=None)]
-    ext_preds = Predictor.query.filter(
-        Predictor.id.in_(set(all_pred_ids) - set(base_pred_ids)))
-
-    pes = PredictorEvent.query.filter(
-        (PredictorEvent.predictor_id.in_(base_pred_ids)) &
-        (PredictorEvent.run_id.in_(run_id)))
-    pes = dump_pe(pes)
-
-    pes += create_pes(ext_preds, run_id)
+    pes = dump_predictor_events(
+        [(p['id']) for p in analysis_json['predictors']],
+        run_id
+        )
 
     dataset_path = Path(analysis.dataset.local_path)
     preproc_path = dataset_path / 'derivatives' / 'fmriprep'

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -139,12 +139,17 @@ def test_predictor_create(session,
     assert len(resp) == 3
 
 
-def test_get_predictor_data(auth_client, add_task):
-    # List of predictors
-    resp = auth_client.get('/api/predictor-events')
+def test_get_predictor_data(auth_client, add_task, extract_features):
+    # List of predictors (includes both regular and extracted PEs)
+    pids = [
+        str(p['id']) for p in decode_json(auth_client.get('/api/predictors'))]
+
+    resp = auth_client.get('/api/predictor-events',
+                           params={'predictor_id': ",".join(pids)})
+
     assert resp.status_code == 200
     pe_list = decode_json(resp)
-    assert len(pe_list) == 36
+    assert len(pe_list) == 52
 
     pe = pe_list[0]
     # Get PEs only for one run

--- a/neuroscout/tests/api/test_predictor.py
+++ b/neuroscout/tests/api/test_predictor.py
@@ -137,3 +137,21 @@ def test_predictor_create(session,
     # Test user PC route:
     resp = decode_json(auth_client.get('/api/user/predictors'))
     assert len(resp) == 3
+
+
+def test_get_predictor_data(auth_client, add_task):
+    # List of predictors
+    resp = auth_client.get('/api/predictor-events')
+    assert resp.status_code == 200
+    pe_list = decode_json(resp)
+    assert len(pe_list) == 36
+
+    pe = pe_list[0]
+    # Get PEs only for one run
+    resp = auth_client.get(
+        '/api/predictor-events',
+        params={'predictor_id': pe['predictor_id'], 'run_id': pe['run_id']})
+
+    assert resp.status_code == 200
+    pe_list_filt = decode_json(resp)
+    assert len(pe_list_filt) == 4

--- a/neuroscout/utils/db.py
+++ b/neuroscout/utils/db.py
@@ -46,7 +46,7 @@ def dump_pe(pes):
     res = db.session.connection().execute(statement, params)
     return [
         dict(
-            zip(('onset', 'duration', 'value', 'object_id', 'run_id',
+            zip(('id', 'onset', 'duration', 'value', 'object_id', 'run_id',
                  'predictor_id', 'stimulus_id'), r))
         for r in res
         ]
@@ -69,12 +69,12 @@ def dump_predictor_events(predictor_ids, run_ids=None):
     pes = PredictorEvent.query.filter(
         (PredictorEvent.predictor_id.in_(raw_pred_ids)))
     if run_ids is not None:
-        pes.filter((PredictorEvent.run_id.in_(run_ids)))
+        pes = pes.filter((PredictorEvent.run_id.in_(run_ids)))
+
     pes = dump_pe(pes)
 
     # Create & dump Extracted PEs
     pes += create_pes(ext_preds, run_ids)
-
     return pes
 
 

--- a/neuroscout/utils/db.py
+++ b/neuroscout/utils/db.py
@@ -3,11 +3,39 @@
 """
 from flask import abort, current_app
 from sqlalchemy.exc import SQLAlchemyError
-from ..models import Analysis
+from ..models import Analysis, RunStimulus, Predictor, PredictorEvent
 from ..database import db
 from sqlalchemy.event import listens_for
 from sqlalchemy.dialects import postgresql
 from hashids import Hashids
+
+
+def create_pes(predictors, run_ids=None):
+    """ Create PredictorEvents from EFs """
+    all_pes = []
+    for pred in predictors:
+        ef = pred.extracted_feature
+        # For all instances for stimuli in this task's runs
+        for ee in ef.extracted_events:
+            query = RunStimulus.query.filter_by(stimulus_id=ee.stimulus_id)
+            if run_ids is not None:
+                query = query.filter(RunStimulus.run_id.in_(run_ids))
+            for rs in query:
+                duration = ee.duration
+                if duration is None:
+                    duration = rs.duration
+                all_pes.append(
+                    dict(
+                        onset=(ee.onset or 0) + rs.onset,
+                        duration=duration,
+                        value=ee.value,
+                        run_id=rs.run_id,
+                        predictor_id=pred.id,
+                        object_id=ee.object_id,
+                        stimulus_id=ee.stimulus_id
+                    )
+                )
+    return all_pes
 
 
 def dump_pe(pes):
@@ -16,14 +44,38 @@ def dump_pe(pes):
     statement = str(pes.statement.compile(dialect=postgresql.dialect()))
     params = pes.statement.compile(dialect=postgresql.dialect()).params
     res = db.session.connection().execute(statement, params)
-    return [{
-      'id': r[0],
-      'onset': r[1],
-      'duration': r[2],
-      'value':  r[3],
-      'run_id': r[5],
-      'predictor_id': r[6]
-      } for r in res]
+    return [
+        dict(
+            zip(('onset', 'duration', 'value', 'object_id', 'run_id',
+                 'predictor_id', 'stimulus_id'), r))
+        for r in res
+        ]
+
+
+def dump_predictor_events(predictor_ids, run_ids=None):
+    """ Query & serialize PredictorEvents, for both Raw and Extracted
+    Predictors (which require creating PEs from EEs)
+    """
+
+    # Query Predictors
+    all_preds = Predictor.query.filter(Predictor.id.in_(predictor_ids))
+
+    # Separate raw and extracted predictors
+    raw_pred_ids = [p.id for p in all_preds.filter_by(ef_id=None)]
+    ext_preds = Predictor.query.filter(
+        Predictor.id.in_(set(predictor_ids) - set(raw_pred_ids)))
+
+    # Query & dump raw PEs
+    pes = PredictorEvent.query.filter(
+        (PredictorEvent.predictor_id.in_(raw_pred_ids)))
+    if run_ids is not None:
+        pes.filter((PredictorEvent.run_id.in_(run_ids)))
+    pes = dump_pe(pes)
+
+    # Create & dump Extracted PEs
+    pes += create_pes(ext_preds, run_ids)
+
+    return pes
 
 
 @listens_for(Analysis, "after_insert")


### PR DESCRIPTION
Closes #706

This generalized the logic used in `tasks.io` to dump `PredictorEvents` even for `ExtractedEvents`. It creates `PredictorEvents` on the fly when necessary. Otherwise, it uses fast dumping for regular `PredictorEvents`.

Same function is used for dumping events in celery/tasks.