### PR TITLE
Dedupe auto contrasts

### DIFF
--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -789,6 +789,10 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
           return stateUpdate.analysis.predictorIds.indexOf(x) > -1;
         }
       );
+      let predictorNames = stateUpdate[selectedPredictors].map(x => x.name);
+      stateUpdate.analysis.contrasts = stateUpdate.analysis.contrasts.filter(cont => {
+        return cont.ConditionList.filter(cond => !predictorNames.includes(cond)).length === 0;
+      });
     }
 
     stateUpdate.unsavedChanges = true;

--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -793,6 +793,9 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
       stateUpdate.analysis.contrasts = stateUpdate.analysis.contrasts.filter(cont => {
         return cont.ConditionList.filter(cond => !predictorNames.includes(cond)).length === 0;
       });
+      stateUpdate.analysis.transformations = stateUpdate.analysis.transformations.filter(xform => {
+        return xform.Input.filter(in_pred => !predictorNames.includes(in_pred)).length === 0;
+      });
     }
 
     stateUpdate.unsavedChanges = true;

--- a/neuroscout/frontend/src/analysis_builder/Contrasts.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Contrasts.tsx
@@ -143,6 +143,11 @@ export class ContrastsTab extends React.Component<ContrastsTabProps, ContrastsTa
       if (x.source === 'fmriprep') {
         return;
       }
+      if (newContrasts.filter(y => {
+        return (y.Name === x.name && y.ConditionList.length === 1 && y.ConditionList[0] === x.name);
+      }).length > 0) {
+        return;
+      }
       let newContrast = emptyContrast();
       newContrast.Name = `${x.name}`;
       newContrast.ConditionList = [ x.name ];


### PR DESCRIPTION
Fixes #678

Also when a predictor is removed from the predictors tab any contrast that includes it is also removed.