### PR TITLE
Deactivate categorical variables

### DIFF
--- a/neuroscout/config/feature_schema.json
+++ b/neuroscout/config/feature_schema.json
@@ -167,28 +167,36 @@
           "description": "Face landmarking confidence"
         },
         "joyLikelihood": {
-          "description": "Joy likelihood."
+          "description": "Joy likelihood.",
+          "active": false
         },
         "sorrowLikelihood": {
-          "description": "Sorrow likelihood."
+          "description": "Sorrow likelihood.",
+          "active": false
         },
         "angerLikelihood": {
-          "description": "Anger likelihood"
+          "description": "Anger likelihood",
+          "active": false
         },
         "surpriseLikelihood": {
-          "description": "Surprise likelihood"
+          "description": "Surprise likelihood",
+          "active": false
         },
         "underExposedLikelihood": {
-          "description": "Under-exposed likelihood."
+          "description": "Under-exposed likelihood.",
+          "active": false
         },
         "blurredLikelihood": {
-          "description" : "Blurred likelihood"
+          "description" : "Blurred likelihood",
+          "active": false
         },
         "headwearLikelihood": {
-          "description": "Headwear likelihood"
+          "description": "Headwear likelihood",
+          "active": false
         },
         "num_faces": {
-          "description": "Number of detected faces in scene"
+          "description": "Number of detected faces in scene",
+          "active": false
         }
       }
     }
@@ -219,19 +227,24 @@
     {
       "features": {
         "adult": {
-          "description": "Likelihood of nudity, pornographic images or cartoons, or sexual activities"
+          "description": "Likelihood of nudity, pornographic images or cartoons, or sexual activities",
+          "active": false
         },
         "spoof": {
-          "description": "Likelihood that an modification was made to the image's canonical version to make it appear funny or offensive"
+          "description": "Likelihood that an modification was made to the image's canonical version to make it appear funny or offensive",
+          "active": false
         },
         "medical": {
-          "description": "Likelihood that this is a medical image"
+          "description": "Likelihood that this is a medical image",
+          "active": false
         },
         "violence": {
-          "description": "Likelihood that this image contains violent content"
+          "description": "Likelihood that this image contains violent content",
+          "active": false
         },
         "racy": {
-          "description": "Likelihood that this image contains racy content"
+          "description": "Likelihood that this image contains racy content",
+          "active": false
           }
       }
 

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -25,7 +25,7 @@ class PredictorResource(MethodResource):
         return first_or_404(Predictor.query.filter_by(id=predictor_id))
 
 
-def get_predictors(newest=True, user=None, **kwargs):
+def get_predictors(newest=True, active=True, user=None, **kwargs):
     """ Helper function for querying newest predictors """
     if newest:
         predictor_ids = db.session.query(
@@ -43,7 +43,7 @@ def get_predictors(newest=True, user=None, **kwargs):
     for param in kwargs:
         query = query.filter(getattr(Predictor, param).in_(kwargs[param]))
 
-    query = query.filter_by(active=True)
+    query = query.filter_by(active=active)
 
     if user is not None:
         query = query.filter_by(private=True).join(
@@ -62,6 +62,9 @@ class PredictorListResource(MethodResource):
             wa.fields.Int(), description="Run id(s). Warning, slow query."),
         'name': wa.fields.DelimitedList(wa.fields.Str(),
                                         description="Predictor name(s)"),
+        'active': wa.fields.Boolean(
+            missing=True,
+            description="Return only active Predictors"),
         'newest': wa.fields.Boolean(
             missing=True,
             description="Return only newest Predictor by name")
@@ -71,7 +74,8 @@ class PredictorListResource(MethodResource):
     @marshal_with(PredictorSchema(many=True))
     def get(self, **kwargs):
         newest = kwargs.pop('newest')
-        return get_predictors(newest=newest, **kwargs)
+        active = kwargs.pop('active')
+        return get_predictors(newest=newest, active=active, **kwargs)
 
 
 def prepare_upload(collection_name, event_files, runs, dataset_id):


### PR DESCRIPTION
Closes  #728

- Deactivates categorical variables by default
- Adds `active` as kwargs to `PredictorList` resource/API route

This should not change how pyNS or the frontend client interactive with the API. 