### PR TITLE
Add f test to upload types

### DIFF
--- a/neuroscout/tasks/upload.py
+++ b/neuroscout/tasks/upload.py
@@ -109,6 +109,7 @@ def upload_collection(flask_app, filenames, runs, dataset_id, collection_id,
 
 MAP_TYPE_CHOICES = {
     't': 'T',
+    'F': 'F',
     'p': 'P',
     'effect': 'U',
     'variance': 'V',


### PR DESCRIPTION
In worker, accept F test stat images as valid upload types to NeuroVault