### PR TITLE
check if analysis is public or owned before rendering analysis builder in routes

### DIFF
--- a/neuroscout/frontend/src/Routes.tsx
+++ b/neuroscout/frontend/src/Routes.tsx
@@ -43,14 +43,23 @@ export default class Routes extends React.Component<AppState, {}> {
         />
         <Route
           path="/builder/:id"
-          render={props =>
-            <AnalysisBuilder
+          render={props => {
+            let id = props.match.params.id;
+            if (
+              !this.props.publicAnalyses.some(elem => elem.id === id)
+              && !this.props.analyses.some(elem => elem.id === id)
+            ) {
+              message.warning('Analyses is currently private');
+              return <Redirect to="/" />;
+            }
+            return <AnalysisBuilder
               id={props.match.params.id}
               updatedAnalysis={() => this.props.loadAnalyses()}
               userOwns={this.props.analyses.filter((x) => x.id === props.match.params.id).length > 0}
               datasets={this.props.datasets}
               doTooltip={true}
-            />}
+            />;
+          }}
         />
         <Route
           exact={true}

--- a/neuroscout/frontend/src/Routes.tsx
+++ b/neuroscout/frontend/src/Routes.tsx
@@ -44,14 +44,6 @@ export default class Routes extends React.Component<AppState, {}> {
         <Route
           path="/builder/:id"
           render={props => {
-            let id = props.match.params.id;
-            if (
-              !this.props.publicAnalyses.some(elem => elem.id === id)
-              && !this.props.analyses.some(elem => elem.id === id)
-            ) {
-              message.warning('Analyses is currently private');
-              return <Redirect to="/" />;
-            }
             return <AnalysisBuilder
               id={props.match.params.id}
               updatedAnalysis={() => this.props.loadAnalyses()}

--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -7,7 +7,7 @@ import { Redirect } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 import * as React from 'react';
 import {
-  Tag, Tabs, Row, Button, Modal, Icon, message, Tooltip, Form, Input, Collapse
+  Alert, Tag, Tabs, Row, Button, Modal, Icon, message, Tooltip, Form, Input, Collapse
 } from 'antd';
 import { Prompt } from 'react-router-dom';
 import Reflux from 'reflux';
@@ -1108,6 +1108,13 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
                 className="builderTabs"
                 tabPosition="left"
               >
+                {!this.props.userOwns && isDraft &&
+                  <Alert
+                    message="Read Only"
+                    type="info"
+                    showIcon={true}
+                  />
+                }
                 {isEditable && <TabPane tab="Overview" key="overview" disabled={!isEditable}>
                   <h2>Overview</h2>
                   <OverviewTab

--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -1110,9 +1110,10 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
               >
                 {!this.props.userOwns && isDraft &&
                   <Alert
-                    message="Read Only"
+                    message="This analysis is a draft and is currently read only. Only the owner of this draft can edit it."
                     type="info"
                     showIcon={true}
+                    style={{ marginBottom: '.5em' }}
                   />
                 }
                 {isEditable && <TabPane tab="Overview" key="overview" disabled={!isEditable}>

--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -244,6 +244,9 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
       })
       .then((data: ApiAnalysis) => {
         if (this.state.analysis404) { return; }
+        if (!this.props.userOwns && editableStatus.includes(data.status)) {
+          editableStatus = [];
+        }
         if (editableStatus.includes(data.status)) {
           this.setState({model: this.buildModel()});
         } else if (data.model !== undefined) {
@@ -251,9 +254,6 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
         }
         if (data.status === 'FAILED') {
           this.setState({activeTab: 'submit'});
-        }
-        if (!this.props.userOwns && editableStatus.includes(data.status)) {
-          editableStatus = [];
         }
       })
       .catch(displayError);

--- a/neuroscout/frontend/src/analysis_builder/Builder.tsx
+++ b/neuroscout/frontend/src/analysis_builder/Builder.tsx
@@ -55,7 +55,7 @@ const history = createBrowserHistory();
 // const logo = require('./logo.svg');
 const domainRoot = config.server_url;
 const DEFAULT_SMOOTHING = 5;
-const editableStatus = ['DRAFT', 'FAILED'];
+let editableStatus = ['DRAFT', 'FAILED'];
 
 const defaultConfig: AnalysisConfig = { smoothing: DEFAULT_SMOOTHING, predictorConfigs: {} };
 
@@ -226,6 +226,7 @@ type BuilderProps = {
 export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps & RouteComponentProps<{}>, Store> {
   constructor(props: BuilderProps) {
     super(props);
+    editableStatus = ['DRAFT', 'FAILED'];
     this.state = initializeStore();
     this.store = AuthStore;
     // Load analysis from server if an analysis id is specified in the props
@@ -250,6 +251,9 @@ export default class AnalysisBuilder extends Reflux.Component<any, BuilderProps 
         }
         if (data.status === 'FAILED') {
           this.setState({activeTab: 'submit'});
+        }
+        if (!this.props.userOwns && editableStatus.includes(data.status)) {
+          editableStatus = [];
         }
       })
       .catch(displayError);


### PR DESCRIPTION
Fixes #759.

Redirects back to main page and displays a warning if user attempts to browse non public dataset that they don't own.

This would prevent private analyses from being viewed by non owners who have the id, is that something we want?