### PR TITLE
Add stimulus timing to /predictor-events route

### DIFF
--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -185,4 +185,4 @@ class PredictorEventListResource(MethodResource):
         only = ['onset', 'duration', 'value', 'run_id', 'predictor_id'] \
             if not stimulus_timing else None
 
-        return PredictorEventSchema(many=True, only=only).dump(res)
+        return PredictorEventSchema(many=True, only=only).dump(res)[0]

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -166,6 +166,7 @@ class PredictorCollectionResource(MethodResource):
 
 class PredictorEventListResource(MethodResource):
     @doc(tags=['predictors'], summary='Get events for predictor(s)',)
+    @marshal_with(PredictorEventSchema(many=True))
     @use_kwargs({
         'run_id': wa.fields.DelimitedList(
             wa.fields.Int(),
@@ -179,10 +180,6 @@ class PredictorEventListResource(MethodResource):
             description="Return stimulus timing and information")
         }, locations=['query'])
     @cache.cached(60 * 60 * 24 * 300, query_string=True)
-    def get(self, predictor_id, run_id=None, stimulus_timing=None):
-        res = dump_predictor_events(predictor_id, run_id)
-
-        only = ['onset', 'duration', 'value', 'run_id', 'predictor_id'] \
-            if not stimulus_timing else None
-
-        return PredictorEventSchema(many=True, only=only).dump(res)[0]
+    def get(self, predictor_id, run_id=None, stimulus_timing=False):
+        return dump_predictor_events(
+            predictor_id, run_id, stimulus_timing=stimulus_timing)

--- a/neuroscout/resources/predictor.py
+++ b/neuroscout/resources/predictor.py
@@ -166,7 +166,6 @@ class PredictorCollectionResource(MethodResource):
 
 class PredictorEventListResource(MethodResource):
     @doc(tags=['predictors'], summary='Get events for predictor(s)',)
-    @marshal_with(PredictorEventSchema(many=True))
     @use_kwargs({
         'run_id': wa.fields.DelimitedList(
             wa.fields.Int(),
@@ -175,7 +174,15 @@ class PredictorEventListResource(MethodResource):
             wa.fields.Int(),
             description="Predictor id(s)",
             required=True),
-    }, locations=['query'])
+        'stimulus_timing': wa.fields.Boolean(
+            missing=False,
+            description="Return stimulus timing and information")
+        }, locations=['query'])
     @cache.cached(60 * 60 * 24 * 300, query_string=True)
-    def get(self, predictor_id, run_id=None):
-        return dump_predictor_events(predictor_id, run_id)
+    def get(self, predictor_id, run_id=None, stimulus_timing=None):
+        res = dump_predictor_events(predictor_id, run_id)
+
+        only = ['onset', 'duration', 'value', 'run_id', 'predictor_id'] \
+            if not stimulus_timing else None
+
+        return PredictorEventSchema(many=True, only=only).dump(res)

--- a/neuroscout/schemas/predictor.py
+++ b/neuroscout/schemas/predictor.py
@@ -58,4 +58,4 @@ class PredictorEventSchema(Schema):
     stimulus_id = fields.Int(description='Stimulus id')
     stimulus_onset = fields.Number(description='Stimulus onset')
     stimulus_duration = fields.Number(description='Stimulus duration')
-    stimulus_path = fields.Number(description='Stimulus path')
+    stimulus_path = fields.Str(description='Stimulus path')

--- a/neuroscout/schemas/predictor.py
+++ b/neuroscout/schemas/predictor.py
@@ -55,3 +55,7 @@ class PredictorEventSchema(Schema):
     value = fields.Str(description="Value, or amplitude.")
     run_id = fields.Int()
     predictor_id = fields.Int()
+    stimulus_id = fields.Int(description='Stimulus id')
+    stimulus_onset = fields.Number(description='Stimulus onset')
+    stimulus_duration = fields.Number(description='Stimulus duration')
+    stimulus_path = fields.Number(description='Stimulus path')

--- a/neuroscout/utils/db.py
+++ b/neuroscout/utils/db.py
@@ -95,7 +95,7 @@ def dump_predictor_events(predictor_ids, run_ids=None, stimulus_timing=False):
     pes = dump_pe(pes)
 
     # Create & dump Extracted PEs
-    pes += create_pes(ext_preds, run_ids)
+    pes += create_pes(ext_preds, run_ids, stimulus_timing=stimulus_timing)
     return pes
 
 

--- a/neuroscout/utils/db.py
+++ b/neuroscout/utils/db.py
@@ -28,11 +28,15 @@ def create_pes(predictors, run_ids=None):
             'extracted_event.onset', 'extracted_event.duration',
             'extracted_event.value', 'extracted_event.object_id',
             'extracted_event.stimulus_id', 'run_stimulus.run_id',
-            'run_stimulus.onset', 'run_stimulus.duration')
+            'run_stimulus.onset', 'run_stimulus.duration',
+            'stimulus.path')
 
-        for onset, dur, val, o_id, s_id, run_id, rs_onset, rs_dur in query:
+        for (onset, dur, val, o_id, s_id, run_id, rs_onset, rs_dur, s_path) \
+                in query:
             if dur is None:
                 dur = rs_dur
+            s_path = s_path.split('/')[-1] if s_path else None
+
             all_pes.append(
                 dict(
                     onset=(onset or 0) + rs_onset,
@@ -41,7 +45,10 @@ def create_pes(predictors, run_ids=None):
                     run_id=run_id,
                     predictor_id=pred.id,
                     object_id=o_id,
-                    stimulus_id=s_id
+                    stimulus_id=s_id,
+                    stimulus_onset=rs_onset,
+                    stimulus_duration=rs_dur,
+                    stimulus_path=s_path
                 )
             )
     return all_pes

--- a/neuroscout/utils/db.py
+++ b/neuroscout/utils/db.py
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 from hashids import Hashids
 
 
-def create_pes(predictors, run_ids=None):
+def create_pes(predictors, run_ids=None, stimulus_timing=False):
     """ Create PredictorEvents from EFs """
     all_pes = []
     for pred in predictors:
@@ -37,20 +37,25 @@ def create_pes(predictors, run_ids=None):
                 dur = rs_dur
             s_path = s_path.split('/')[-1] if s_path else None
 
-            all_pes.append(
-                dict(
+            res = dict(
                     onset=(onset or 0) + rs_onset,
                     duration=dur,
                     value=val,
                     run_id=run_id,
                     predictor_id=pred.id,
                     object_id=o_id,
+                )
+
+            if stimulus_timing:
+                res.update(dict(
                     stimulus_id=s_id,
                     stimulus_onset=rs_onset,
                     stimulus_duration=rs_dur,
                     stimulus_path=s_path
+                    )
                 )
-            )
+
+            all_pes.append(res)
     return all_pes
 
 
@@ -68,7 +73,7 @@ def dump_pe(pes):
         ]
 
 
-def dump_predictor_events(predictor_ids, run_ids=None):
+def dump_predictor_events(predictor_ids, run_ids=None, stimulus_timing=False):
     """ Query & serialize PredictorEvents, for both Raw and Extracted
     Predictors (which require creating PEs from EEs)
     """


### PR DESCRIPTION
This PR allow users to say `predictor_timing=True` in the `/predictor-events` route and get back information about the stimulus associated with the event, including the timing information (for that run) and path (truncated) of the stimulus used.

For now, I'm not serving the stimuli to the world, so this is only useful internally. 