### PR TITLE
Adds loading spinner for public/private analyses list.

### DIFF
--- a/neuroscout/frontend/src/AnalysisList.tsx
+++ b/neuroscout/frontend/src/AnalysisList.tsx
@@ -11,7 +11,7 @@ import { Link } from 'react-router-dom';
 export interface AnalysisListProps {
   loggedIn?: boolean;
   publicList?: boolean;
-  analyses: AppAnalysis[];
+  analyses: (AppAnalysis[] | null);
   cloneAnalysis: (id: string) => void;
   onDelete?: (analysis: AppAnalysis) => void;
   children?: React.ReactNode;
@@ -97,12 +97,13 @@ class AnalysisListTable extends React.Component<AnalysisListProps> {
           columns={analysisTableColumns}
           rowKey="id"
           size="small"
-          dataSource={analyses}
+          dataSource={(analyses === null ? [] : analyses)}
+          loading={analyses === null}
           expandedRowRender={record =>
             <p>
               {record.description}
             </p>}
-          pagination={(analyses.length > 20) ? {'position': 'bottom'} : false}
+          pagination={(analyses !== null && analyses.length > 20) ? {'position': 'bottom'} : false}
         />
       </div>
     );

--- a/neuroscout/frontend/src/Routes.tsx
+++ b/neuroscout/frontend/src/Routes.tsx
@@ -47,7 +47,10 @@ export default class Routes extends React.Component<AppState, {}> {
             <AnalysisBuilder
               id={props.match.params.id}
               updatedAnalysis={() => this.props.loadAnalyses()}
-              userOwns={this.props.analyses.filter((x) => x.id === props.match.params.id).length > 0}
+              userOwns={
+                (this.props.analyses === null ? false
+                  : this.props.analyses.filter((x) => x.id === props.match.params.id).length > 0)
+              }
               datasets={this.props.datasets}
               doTooltip={true}
             />}
@@ -59,7 +62,10 @@ export default class Routes extends React.Component<AppState, {}> {
             <AnalysisBuilder
               id={props.match.params.id}
               updatedAnalysis={() => this.props.loadAnalyses()}
-              userOwns={this.props.analyses.filter((x) => x.id === props.match.params.id).length > 0}
+              userOwns={
+                (this.props.analyses === null ? false
+                  : this.props.analyses.filter((x) => x.id === props.match.params.id).length > 0)
+              }
               datasets={this.props.datasets}
               doTooltip={true}
             />

--- a/neuroscout/frontend/src/coretypes.ts
+++ b/neuroscout/frontend/src/coretypes.ts
@@ -317,8 +317,8 @@ export interface AuthStoreState {
 
 export interface AppState {
   loadAnalyses: () => void;
-  analyses: AppAnalysis[]; // List of analyses belonging to the user
-  publicAnalyses: AppAnalysis[]; // List of public analyses
+  analyses: (AppAnalysis[] | null); // List of analyses belonging to the user
+  publicAnalyses: (AppAnalysis[] | null); // List of public analyses
   auth: AuthStoreState;
   datasets: Dataset[];
   cloneAnalysis: (number) => void;


### PR DESCRIPTION
Allow analyses and public analyses to be null by default. If null we show loading symbol on analyses list. If there are no analyses or and error occurs the analyses variable recieves an empty list so the loading symbol will go away.

fixes #776 