### PR TITLE
Speed up and fix My Analyses

### DIFF
--- a/neuroscout/frontend/src/App.tsx
+++ b/neuroscout/frontend/src/App.tsx
@@ -42,7 +42,7 @@ let checkCount = 0;
 
 class JWTChange extends React.Component<JWTChangeProps, {}> {
   jwtChanged = memoize((jwt, user_name) => {
-    if (!!jwt && user_name > 0) {
+    if (!!jwt && !!user_name) {
       this.props.loadAnalyses();
       checkCount += 1;
       this.props.checkAnalysesStatus(checkCount);

--- a/neuroscout/resources/analysis/endpoints.py
+++ b/neuroscout/resources/analysis/endpoints.py
@@ -26,7 +26,7 @@ class AnalysisMethodResource(MethodResource):
 class AnalysisRootResource(AnalysisMethodResource):
     """" Resource for root address """
     @marshal_with(AnalysisSchema(many=True,
-                                 only=['id', 'name', 'description', 'status',
+                                 only=['hash_id', 'name', 'description', 'status',
                                        'dataset_id', 'modified_at', 'user']))
     @doc(summary='Returns list of public analyses.')
     @use_kwargs({

--- a/neuroscout/resources/analysis/endpoints.py
+++ b/neuroscout/resources/analysis/endpoints.py
@@ -25,7 +25,9 @@ class AnalysisMethodResource(MethodResource):
 
 class AnalysisRootResource(AnalysisMethodResource):
     """" Resource for root address """
-    @marshal_with(AnalysisSchema(many=True))
+    @marshal_with(AnalysisSchema(many=True,
+                                 only=['id', 'name', 'description', 'status',
+                                       'dataset_id', 'modified_at', 'user']))
     @doc(summary='Returns list of public analyses.')
     @use_kwargs({
         'name': wa.fields.DelimitedList(

--- a/neuroscout/resources/user.py
+++ b/neuroscout/resources/user.py
@@ -58,7 +58,7 @@ class UserListResource(MethodResource):
 
 @marshal_with(AnalysisSchema(many=True,
                              only=['id', 'name', 'description', 'status',
-                                   'dataset_id', 'modified_at', 'user_name']))
+                                   'dataset_id', 'modified_at', 'user']))
 class UserPrivateAnalysisListResource(MethodResource):
     @doc(tags=['user'], summary='Get a list of analyses created by a user.')
     @auth_required
@@ -69,7 +69,7 @@ class UserPrivateAnalysisListResource(MethodResource):
 
 @marshal_with(AnalysisSchema(many=True,
                              only=['id', 'name', 'description', 'status',
-                                   'dataset_id', 'modified_at', 'user_name']))
+                                   'dataset_id', 'modified_at', 'user']))
 class UserAnalysisListResource(MethodResource):
     @doc(tags=['user'], summary='Get a list of analyses created by a user.')
     def get(self, user_name):

--- a/neuroscout/resources/user.py
+++ b/neuroscout/resources/user.py
@@ -57,7 +57,7 @@ class UserListResource(MethodResource):
 
 
 @marshal_with(AnalysisSchema(many=True,
-                             only=['id', 'name', 'description', 'status',
+                             only=['hash_id', 'name', 'description', 'status',
                                    'dataset_id', 'modified_at', 'user']))
 class UserPrivateAnalysisListResource(MethodResource):
     @doc(tags=['user'], summary='Get a list of analyses created by a user.')
@@ -68,7 +68,7 @@ class UserPrivateAnalysisListResource(MethodResource):
 
 
 @marshal_with(AnalysisSchema(many=True,
-                             only=['id', 'name', 'description', 'status',
+                             only=['hash_id', 'name', 'description', 'status',
                                    'dataset_id', 'modified_at', 'user']))
 class UserAnalysisListResource(MethodResource):
     @doc(tags=['user'], summary='Get a list of analyses created by a user.')

--- a/neuroscout/resources/user.py
+++ b/neuroscout/resources/user.py
@@ -48,15 +48,6 @@ class UserDetailResource(MethodResource):
         return first_or_404(User.query.filter_by(user_name=user_name))
 
 
-@marshal_with(AnalysisSchema(many=True))
-class UserPrivateAnalysisListResource(MethodResource):
-    @doc(tags=['user'], summary='Get a list of analyses created by a user.')
-    @auth_required
-    def get(self):
-        kwargs = {'user_id': current_identity.id}
-        return Analysis.query.filter_by(**kwargs)
-
-
 @marshal_with(UserPublicSchema(
     many=True,  exclude=['predictor_collections', 'first_login']))
 class UserListResource(MethodResource):
@@ -65,7 +56,20 @@ class UserListResource(MethodResource):
         return User.query.all()
 
 
-@marshal_with(AnalysisSchema(many=True))
+@marshal_with(AnalysisSchema(many=True,
+                             only=['id', 'name', 'description', 'status',
+                                   'dataset_id', 'modified_at', 'user_name']))
+class UserPrivateAnalysisListResource(MethodResource):
+    @doc(tags=['user'], summary='Get a list of analyses created by a user.')
+    @auth_required
+    def get(self):
+        kwargs = {'user_id': current_identity.id}
+        return Analysis.query.filter_by(**kwargs)
+
+
+@marshal_with(AnalysisSchema(many=True,
+                             only=['id', 'name', 'description', 'status',
+                                   'dataset_id', 'modified_at', 'user_name']))
 class UserAnalysisListResource(MethodResource):
     @doc(tags=['user'], summary='Get a list of analyses created by a user.')
     def get(self, user_name):


### PR DESCRIPTION
/myanalyses is quite slow right now.

One improvement is to only return the fields that matter for the listing, for both private and public analyses.

This seems to reduce the data transfered by 5x and speed up the query by up to 10x. 

However, I'm still getting a situation where the query hangs on the frontend, and I only see a spinning icon. 
I tested this with an account with only a few analyses, so I don't think having too many analyses is the issue.

Instead, I think there's scenarios where the logic goes awry and it just hangs.