### PR TITLE
Add Extractor description API route

### DIFF
--- a/neuroscout/config/feature_schema.json
+++ b/neuroscout/config/feature_schema.json
@@ -13,7 +13,7 @@
       }
     }
   ],
-  "PretrainedBertEncodingExtractor": [
+  "BertExtractor": [
     {
       "features": {
         "encoding$": {

--- a/neuroscout/core.py
+++ b/neuroscout/core.py
@@ -64,7 +64,8 @@ route_factory(
         ('TaskResource', 'tasks/<int:task_id>'),
         ('TaskPredictorsResource', 'tasks/<int:task_id>/predictors'),
         ('TaskListResource', 'tasks'),
-        ('ImageVersionResource', 'image_version')
+        ('ImageVersionResource', 'image_version'),
+        ('ExtractorListResource', 'extractors')
     ])
 
 

--- a/neuroscout/resources/__init__.py
+++ b/neuroscout/resources/__init__.py
@@ -7,6 +7,7 @@ from .analysis import (AnalysisResource, AnalysisRootResource,
                        AnalysisFillResource, AnalysisUploadResource,
                        BibliographyResource, ImageVersionResource)
 from .dataset import DatasetResource, DatasetListResource
+from .extractor import ExtractorListResource
 from .predictor import (PredictorListResource, PredictorResource,
                         PredictorCollectionCreateResource,
                         TaskPredictorsResource,
@@ -34,6 +35,7 @@ __all__ = [
     'ReportResource',
     'DatasetResource',
     'DatasetListResource',
+    'ExtractorListResource',
     'PredictorResource',
     'PredictorListResource',
     'PredictorEventListResource',

--- a/neuroscout/resources/extractor.py
+++ b/neuroscout/resources/extractor.py
@@ -1,0 +1,30 @@
+import json
+import re
+from pliers import extractors as piext
+from flask_apispec import MethodResource, marshal_with, doc
+from flask import current_app
+from ..core import cache
+from ..schemas.extractor import ExtractorSchema
+
+
+class ExtractorListResource(MethodResource):
+    @doc(tags=['extractor'], summary='Extractor descriptions')
+    @cache.cached(60 * 60 * 24 * 300, query_string=True)
+    @marshal_with(ExtractorSchema(many=True))
+    def get(self, **kwargs):
+        schema = json.load(open(current_app.config['FEATURE_SCHEMA']))
+
+        result = []
+        extractors = schema.keys()
+        for ext in extractors:
+            docstring = getattr(piext, ext).__doc__
+
+            # Only return docstring prior to Args section
+            desc = docstring.split('Args')[0].replace('\n', '').strip(' ')
+            desc = re.sub('\\s+', ' ', desc)  # Replace multiple spaces
+            result.append({
+                'name': ext,
+                'description': desc
+                })
+
+        return result

--- a/neuroscout/resources/extractor.py
+++ b/neuroscout/resources/extractor.py
@@ -17,14 +17,17 @@ class ExtractorListResource(MethodResource):
         result = []
         extractors = schema.keys()
         for ext in extractors:
-            docstring = getattr(piext, ext).__doc__
+            try:
+                docstring = getattr(piext, ext).__doc__
 
-            # Only return docstring prior to Args section
-            desc = docstring.split('Args')[0].replace('\n', '').strip(' ')
-            desc = re.sub('\\s+', ' ', desc)  # Replace multiple spaces
-            result.append({
-                'name': ext,
-                'description': desc
-                })
+                # Only return docstring prior to Args section
+                desc = docstring.split('Args')[0].replace('\n', '').strip(' ')
+                desc = re.sub('\\s+', ' ', desc)  # Replace multiple spaces
+                result.append({
+                    'name': ext,
+                    'description': desc
+                    })
+            except AttributeError:
+                pass
 
         return result

--- a/neuroscout/schemas/extractor.py
+++ b/neuroscout/schemas/extractor.py
@@ -1,0 +1,7 @@
+from marshmallow import fields, Schema
+
+
+class ExtractorSchema(Schema):
+    """ Extractor documentation schema. """
+    name = fields.Str(description='Extractor name')
+    description = fields.Str(description='Extractor description')

--- a/neuroscout/tests/api/test_extractor.py
+++ b/neuroscout/tests/api/test_extractor.py
@@ -1,0 +1,19 @@
+from ..request_utils import decode_json
+
+
+def test_get_dataset(auth_client, add_local_task_json):
+    # List of datasets
+    resp = auth_client.get('/api/extractors')
+    assert resp.status_code == 200
+    dataset_list = decode_json(resp)
+    assert type(dataset_list) == list
+
+    # Get first dataset
+    assert 'description' in dataset_list[0]
+    assert 'name' in dataset_list[0]
+
+    assert len(dataset_list) > 20
+
+    ext = [ext for ext in dataset_list if ext['name'] == 'RMSExtractor'][0]
+
+    assert 'Extracts root mean square (RMS) from audio' in ext['description']

--- a/neuroscout/tests/api/test_extractor.py
+++ b/neuroscout/tests/api/test_extractor.py
@@ -14,6 +14,6 @@ def test_extractor_desc(auth_client, add_local_task_json):
 
     assert len(ext_list) > 2
 
-    ext = [ext for ext in ext_list if ext['name'] == 'RMSExtractor'][0]
+    ext = [ext for ext in ext_list if ext['name'] == 'BrightnessExtractor'][0]
 
-    assert 'Extracts root mean square (RMS) from audio' in ext['description']
+    assert 'average luminosity of the pixels' in ext['description']

--- a/neuroscout/tests/api/test_extractor.py
+++ b/neuroscout/tests/api/test_extractor.py
@@ -1,19 +1,19 @@
 from ..request_utils import decode_json
 
 
-def test_get_dataset(auth_client, add_local_task_json):
+def test_extractor_desc(auth_client, add_local_task_json):
     # List of datasets
     resp = auth_client.get('/api/extractors')
     assert resp.status_code == 200
-    dataset_list = decode_json(resp)
-    assert type(dataset_list) == list
+    ext_list = decode_json(resp)
+    assert type(ext_list) == list
 
     # Get first dataset
-    assert 'description' in dataset_list[0]
-    assert 'name' in dataset_list[0]
+    assert 'description' in ext_list[0]
+    assert 'name' in ext_list[0]
 
-    assert len(dataset_list) > 20
+    assert len(ext_list) > 2
 
-    ext = [ext for ext in dataset_list if ext['name'] == 'RMSExtractor'][0]
+    ext = [ext for ext in ext_list if ext['name'] == 'RMSExtractor'][0]
 
     assert 'Extracts root mean square (RMS) from audio' in ext['description']


### PR DESCRIPTION
For #820 #870 need API route with descriptions for extractors.

Instead of adding to the db and over-complicating, I decided to just scrape the doc strings from Pliers and return via API. We can cache this route to ensure adequate performance.