### PR TITLE
[FIX] change keyserver to ubuntu

### DIFF
--- a/neuroscout/Dockerfile
+++ b/neuroscout/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get install -yq ffmpeg tesseract-ocr apt-transport-https libnss3 xvfb
 RUN pip install -e git+https://github.com/PsychoinformaticsLab/pliers.git#egg=pliers
 RUN pip install clarifai duecredit google-api-python-client IndicoIo librosa>=0.6.3 pysrt pytesseract spacy rev_ai
 
-RUN wget -O- http://neuro.debian.net/lists/stretch.us-nh.full | tee /etc/apt/sources.list.d/neurodebian.sources.list && apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net 0xA5D32F012649A5A9
+RUN wget -O- http://neuro.debian.net/lists/stretch.us-nh.full | tee /etc/apt/sources.list.d/neurodebian.sources.list && apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com 0xA5D32F012649A5A9
 RUN apt-get update && apt-get install -yq datalad && pip install datalad
 
 RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -


### PR DESCRIPTION
looks like the existing key-server is deprecated: https://sks-keyservers.net/

This changes the keyserver to the one suggested by neurodebian: https://neuro.debian.net/