### PR TITLE
set resolver to dockers internal dns for first 30 seconds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ PYTHONUNBUFFERED=0
 COMPOSE_CONVERT_WINDOWS_PATHS=1
 DB_PATH=/path/to/db_data
 V_HOST=neuroscout.org
+V_HOSTS=neuroscout.org,neuroscout.psy.utexas.edu

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -48,7 +48,6 @@ http {
         client_max_body_size 500m;
 
        server {
-            resolver 127.0.0.11 valid=30s;
             server_name _;
             root /neuroscout/neuroscout/frontend/build;
 
@@ -72,8 +71,7 @@ http {
             }
 
             location /api/swagger/ {
-                set $swagger http://swagger-ui:8080/;
-                proxy_pass $swagger;
+                proxy_pass http://swagger-ui:8080/;
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -70,7 +70,7 @@ http {
                 return 301 /api/swagger/;
             }
 
-            location /api/swagger/ {
+            location ^~ /api/swagger/ {
                 proxy_pass http://swagger-ui:8080/;
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -48,6 +48,7 @@ http {
         client_max_body_size 500m;
 
        server {
+            resolver 127.0.0.11 valid=30s;
             server_name _;
             root /neuroscout/neuroscout/frontend/build;
 


### PR DESCRIPTION
If the swagger containers hostname wouldn't resolve nginx would fail to start. I put in the set directive by its proxypass to get around nginx trying to do the hostname lookup on startup. Nginx was complaining about not having a resolver when you visited /api/swagger. Made change according to this:

https://sandro-keil.de/blog/let-nginx-start-if-upstream-host-is-unavailable-or-down/