### PR TITLE
Add production mode and trigger deployment to staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.DEEPDREAM_PRIVATE_KEY }}
+          known_hosts: 'just-a-placeholder-so-we-dont-get-errors'
+          if_key_exists: fail
+
+      - name: Adding Known Hosts
+        run: ssh-keyscan -H ${{ secrets.DEEPDREAM_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy to staging using git post hoo
+        run: |
+         git remote add git@${{ secrets.DEEPDREAM_HOST }}:neuroscout
+         git push deepdream
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
       - "API_URL=http://localhost/swagger/"
 
   neuroscout:
-    command: /usr/local/bin/gunicorn -w 2 -b :8000 neuroscout.core:app --log-level debug --timeout 120 --reload
+    command: cd /neuroscout && /usr/local/bin/gunicorn -w 2 -b :8000 neuroscout.core:app --log-level debug --timeout 120 --reload
     restart: "no"
     build: ./neuroscout
     ports:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,5 @@
+version: "2"
+services:
+  neuroscout:
+    image: ghcr.io/neuroscout/neuroscout:master
+    command: /usr/local/bin/gunicorn -w 2 -b :8000 neuroscout.core:app --log-level debug --timeout 120 --log-file /logs/gunicorn.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,14 @@ services:
     restart: always
     expose:
       - "8000"
+    command: cd /neuroscout && /usr/local/bin/gunicorn -w 2 -b :8000 neuroscout.core:app --log-level debug --timeout 120 --log-file /logs/gunicorn.log
     volumes:
-      - ./postgres/migrations:/migrations
       - ./:/neuroscout
+      - ./postgres/migrations:/migrations
       - ${DATASET_DIR}:/datasets
       - ${KEY_DIR}:/keys
       - ${FILE_DATA}:/file-data
       - /logs/scout:/logs:rw
-    command: /usr/local/bin/gunicorn -w 2 -b :8000 neuroscout.core:app --log-level debug --timeout 120 --log-file /logs/gunicorn.log
     env_file:
       - .env
       - .pliersenv 

--- a/neuroscout/Dockerfile
+++ b/neuroscout/Dockerfile
@@ -38,4 +38,4 @@ RUN git config --global  user.email "delavega@utexas.edu"
 RUN crontab /usr/src/app/update.txt
 RUN service cron start
 
-WORKDIR /neuroscout
+RUN yarn install && yarn build

--- a/neuroscout/Dockerfile
+++ b/neuroscout/Dockerfile
@@ -38,4 +38,6 @@ RUN git config --global  user.email "delavega@utexas.edu"
 RUN crontab /usr/src/app/update.txt
 RUN service cron start
 
+WORKDIR /usr/src/app/frontend
+
 RUN yarn install && yarn build

--- a/neuroscout/Dockerfile
+++ b/neuroscout/Dockerfile
@@ -40,4 +40,7 @@ RUN service cron start
 
 WORKDIR /usr/src/app/frontend
 
+RUN cp /usr/src/app/frontend/src/config.ts.prod /usr/src/app/frontend/src/config.ts
 RUN yarn install && yarn build
+
+WORKDIR /usr/src/app/

--- a/neuroscout/frontend/src/config.ts.prod
+++ b/neuroscout/frontend/src/config.ts.prod
@@ -1,0 +1,7 @@
+export const config = {
+  server_url: 'https://neuroscout.org',
+  google_client_id:
+    '66127382167-v83riq5etne59h7v9ghqqs5t6a3i0rta.apps.googleusercontent.com',
+  ga_key: 'GAKEY',
+  sentry_uri: 'https://96e0d2454fea493e886b3122504e22d3@sentry.io/1776214',
+}


### PR DESCRIPTION
Picks up where #1083 left off:

In all cases, must specify two files, such as :

`docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d`

In the following, the local directory is mapped to `/neuroscout` where `gunicorn` runs

- `docker-compose.dev.yml`: Builds image locally, and also maps port `4000` to allow `yarn start`
- `docker-compose.build.yml`: Builds image locally
- `docker-compose.image.yml`: Pulls image from GHCR, with environment variable `${IMAGE_TAG}` setting the TAG (i.e. `master`, a version, or a pull request).

In `docker-compose.dev.yml`: we run off `/usr/src/app` which is pre-built including the frontend. The image is also fixed to `master`.